### PR TITLE
test: add property-based testing for algebraic law verification

### DIFF
--- a/spec/secp256k1_cross_property_spec.rb
+++ b/spec/secp256k1_cross_property_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'cross-implementation parity', :property do # rubocop:disable Metrics/BlockLength
+  include PropertyHelpers
+
+  # Skip the entire file when the native extension is not available.
+  before(:all) do
+    require 'secp256k1_native'
+  rescue LoadError
+    skip 'Native extension not compiled — run `bundle exec rake compile` first'
+  end
+
+  let(:nat) { Secp256k1Native }
+  let(:p_val) { Secp256k1::P }
+  let(:n_val) { Secp256k1::N }
+  let(:gx) { Secp256k1::GX }
+  let(:gy) { Secp256k1::GY }
+
+  # Convert a Jacobian point [X, Y, Z] to affine [x, y] for comparison.
+  # Different implementations may produce different Z values; affine
+  # coordinates are the canonical form.
+  def to_affine(jac_pt)
+    Secp256k1.jp_to_affine(jac_pt)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Field arithmetic: C extension vs mathematical definition
+  # ---------------------------------------------------------------------------
+  describe 'field arithmetic parity' do # rubocop:disable Metrics/BlockLength
+    it 'fred: C matches x mod P' do
+      check_property('fred parity') do |rng, i|
+        # Use values up to P*P for the first half, smaller values after
+        x = i.even? ? rng.rand(p_val * p_val) : rng.rand(p_val)
+        expect(nat.fred(x)).to eq(x % p_val)
+      end
+    end
+
+    it 'fmul: C matches (a * b) mod P' do
+      check_property('fmul parity') do |rng, _i|
+        a = rng.rand(p_val)
+        b = rng.rand(p_val)
+        expect(nat.fmul(a, b)).to eq((a * b) % p_val)
+      end
+    end
+
+    it 'fsqr: C matches (a * a) mod P' do
+      check_property('fsqr parity') do |rng, _i|
+        a = rng.rand(p_val)
+        expect(nat.fsqr(a)).to eq((a * a) % p_val)
+      end
+    end
+
+    it 'fadd: C matches (a + b) mod P' do
+      check_property('fadd parity') do |rng, _i|
+        a = rng.rand(p_val)
+        b = rng.rand(p_val)
+        expect(nat.fadd(a, b)).to eq((a + b) % p_val)
+      end
+    end
+
+    it 'fsub: C matches (a - b) mod P' do
+      check_property('fsub parity') do |rng, _i|
+        a = rng.rand(p_val)
+        b = rng.rand(p_val)
+        expected = (a - b) % p_val
+        expect(nat.fsub(a, b)).to eq(expected)
+      end
+    end
+
+    it 'fneg: C matches (-a) mod P' do
+      check_property('fneg parity') do |rng, _i|
+        a = rng.rand(p_val)
+        expected = a.zero? ? 0 : p_val - a
+        expect(nat.fneg(a)).to eq(expected)
+      end
+    end
+
+    it 'finv: C matches a^(P-2) mod P' do
+      check_property('finv parity') do |rng, _i|
+        a = 1 + rng.rand(p_val - 1) # non-zero
+        expect(nat.finv(a)).to eq(a.pow(p_val - 2, p_val))
+      end
+    end
+
+    it 'fsqrt: C and Ruby agree on squares of random elements' do
+      check_property('fsqrt parity') do |rng, _i|
+        a = rng.rand(p_val)
+        a_sq = (a * a) % p_val
+
+        c_root = nat.fsqrt(a_sq)
+        ruby_root = a_sq.pow((p_val + 1) / 4, p_val)
+        ruby_root = nil unless (ruby_root * ruby_root) % p_val == a_sq % p_val
+
+        # Both should find a root for a known quadratic residue
+        expect(c_root).not_to be_nil
+        # Compare via squaring — either root (r or P-r) is valid
+        expect(nat.fsqr(c_root)).to eq(a_sq)
+        expect((ruby_root * ruby_root) % p_val).to eq(a_sq)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Scalar arithmetic: C extension vs mathematical definition
+  # ---------------------------------------------------------------------------
+  describe 'scalar arithmetic parity' do # rubocop:disable Metrics/BlockLength
+    it 'scalar_mod: C matches a mod N' do
+      check_property('scalar_mod parity') do |rng, _i|
+        # C extension rejects values exceeding 256 bits, so stay within range
+        a = rng.rand(n_val)
+        expect(nat.scalar_mod(a)).to eq(a % n_val)
+      end
+    end
+
+    it 'scalar_mul: C matches (a * b) mod N' do
+      check_property('scalar_mul parity') do |rng, _i|
+        a = rng.rand(n_val)
+        b = rng.rand(n_val)
+        expect(nat.scalar_mul(a, b)).to eq((a * b) % n_val)
+      end
+    end
+
+    it 'scalar_inv: C matches a^(N-2) mod N' do
+      check_property('scalar_inv parity') do |rng, _i|
+        a = 1 + rng.rand(n_val - 1) # non-zero
+        expect(nat.scalar_inv(a)).to eq(a.pow(n_val - 2, n_val))
+      end
+    end
+
+    it 'scalar_add: C matches (a + b) mod N' do
+      check_property('scalar_add parity') do |rng, _i|
+        a = rng.rand(n_val)
+        b = rng.rand(n_val)
+        expect(nat.scalar_add(a, b)).to eq((a + b) % n_val)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Jacobian point operations: C extension vs Ruby reference
+  #
+  # Jacobian representations may differ (different Z values), so we always
+  # compare in affine coordinates.
+  # ---------------------------------------------------------------------------
+  describe 'Jacobian point operation parity' do # rubocop:disable Metrics/BlockLength
+    # Build a random on-curve Jacobian point from a random scalar k*G.
+    def random_jacobian(rng)
+      k = 1 + rng.rand(Secp256k1::N - 1)
+      pt = Secp256k1::Point.generator.mul_vt(k)
+      [pt.x, pt.y, 1]
+    end
+
+    it 'jp_double: C matches Ruby for random on-curve points' do
+      check_property('jp_double parity') do |rng, _i|
+        jp = random_jacobian(rng)
+        c_result = nat.jp_double(jp)
+        ruby_result = Secp256k1.jp_double(jp)
+        expect(to_affine(c_result)).to eq(to_affine(ruby_result))
+      end
+    end
+
+    it 'jp_add: C matches Ruby for random on-curve point pairs' do
+      check_property('jp_add parity') do |rng, _i|
+        jp1 = random_jacobian(rng)
+        jp2 = random_jacobian(rng)
+        c_result = nat.jp_add(jp1, jp2)
+        ruby_result = Secp256k1.jp_add(jp1, jp2)
+        expect(to_affine(c_result)).to eq(to_affine(ruby_result))
+      end
+    end
+
+    it 'jp_neg: C matches Ruby for random on-curve points' do
+      check_property('jp_neg parity') do |rng, _i|
+        jp = random_jacobian(rng)
+        c_result = nat.jp_neg(jp)
+        ruby_result = Secp256k1.jp_neg(jp)
+        # jp_neg preserves Z, so raw comparison should work,
+        # but use affine for consistency
+        expect(to_affine(c_result)).to eq(to_affine(ruby_result))
+      end
+    end
+
+    it 'scalar_multiply_ct: C matches Ruby for random scalars on G' do
+      check_property('scalar_multiply_ct parity', iterations: 100) do |rng, _i|
+        k = 1 + rng.rand(Secp256k1::N - 1)
+        c_result = nat.scalar_multiply_ct(k, gx, gy)
+        ruby_result = Secp256k1.scalar_multiply_ct(k, gx, gy)
+        expect(to_affine(c_result)).to eq(to_affine(ruby_result))
+      end
+    end
+  end
+end

--- a/spec/secp256k1_property_spec.rb
+++ b/spec/secp256k1_property_spec.rb
@@ -51,4 +51,150 @@ RSpec.describe 'secp256k1 property-based tests', :property do # rubocop:disable 
       expect(PropertyHelpers.iteration_count).to be_positive
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Field arithmetic properties (mod P)
+  # ---------------------------------------------------------------------------
+  describe 'field arithmetic' do # rubocop:disable Metrics/BlockLength
+    # Boundary values near carry boundaries that must be mixed into random
+    # streams to catch carry-propagation and canonicalisation bugs.
+    let(:boundary_values) do
+      p = Secp256k1::P
+      [
+        0, 1, p - 1, p - 2,
+        (1 << 64) - 1, 1 << 64, (1 << 64) + 1,
+        (1 << 128) - 1, 1 << 128, (1 << 128) + 1,
+        (1 << 192) - 1, 1 << 192, (1 << 192) + 1
+      ]
+    end
+
+    # Generate a field element, injecting boundary values for the first few
+    # iterations and then switching to uniform random.
+    def field_element(rng, index, boundaries = boundary_values)
+      index < boundaries.size ? boundaries[index] % p_val : random_field_element(rng)
+    end
+
+    # Same as field_element but guarantees non-zero (for inverse tests).
+    def nonzero_field_element(rng, index, boundaries = boundary_values)
+      v = field_element(rng, index, boundaries)
+      v.zero? ? random_nonzero_field_element(rng) : v
+    end
+
+    it 'fmul commutativity: a*b == b*a' do
+      check_property('fmul commutativity') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        expect(s.fmul(a, b)).to eq(s.fmul(b, a))
+      end
+    end
+
+    it 'fmul associativity: (a*b)*c == a*(b*c)' do
+      check_property('fmul associativity') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        c = random_field_element(rng)
+        expect(s.fmul(s.fmul(a, b), c)).to eq(s.fmul(a, s.fmul(b, c)))
+      end
+    end
+
+    it 'fadd commutativity: a+b == b+a' do
+      check_property('fadd commutativity') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        expect(s.fadd(a, b)).to eq(s.fadd(b, a))
+      end
+    end
+
+    it 'fadd associativity: (a+b)+c == a+(b+c)' do
+      check_property('fadd associativity') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        c = random_field_element(rng)
+        expect(s.fadd(s.fadd(a, b), c)).to eq(s.fadd(a, s.fadd(b, c)))
+      end
+    end
+
+    it 'distributivity: a*(b+c) == a*b + a*c' do
+      check_property('distributivity') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        c = random_field_element(rng)
+        expect(s.fmul(a, s.fadd(b, c))).to eq(s.fadd(s.fmul(a, b), s.fmul(a, c)))
+      end
+    end
+
+    it 'additive identity: a+0 == a' do
+      check_property('additive identity') do |rng, i|
+        a = field_element(rng, i)
+        expect(s.fadd(a, 0)).to eq(a)
+      end
+    end
+
+    it 'multiplicative identity: a*1 == a' do
+      check_property('multiplicative identity') do |rng, i|
+        a = field_element(rng, i)
+        expect(s.fmul(a, 1)).to eq(a)
+      end
+    end
+
+    it 'additive inverse: a + (-a) == 0' do
+      check_property('additive inverse') do |rng, i|
+        a = field_element(rng, i)
+        expect(s.fadd(a, s.fneg(a))).to eq(0)
+      end
+    end
+
+    it 'multiplicative inverse: a * a^-1 == 1 (for a != 0)' do
+      check_property('multiplicative inverse') do |rng, i|
+        a = nonzero_field_element(rng, i)
+        expect(s.fmul(a, s.finv(a))).to eq(1)
+      end
+    end
+
+    it 'negation involution: -(-a) == a' do
+      check_property('negation involution') do |rng, i|
+        a = field_element(rng, i)
+        expect(s.fneg(s.fneg(a))).to eq(a)
+      end
+    end
+
+    it 'subtraction definition: a - b == a + (-b)' do
+      check_property('subtraction definition') do |rng, i|
+        a = field_element(rng, i)
+        b = random_field_element(rng)
+        expect(s.fsub(a, b)).to eq(s.fadd(a, s.fneg(b)))
+      end
+    end
+
+    it 'reduction idempotence: fred(fred(x)) == fred(x)' do
+      check_property('reduction idempotence') do |rng, i|
+        # Use values up to P*P (512-bit) for early iterations, then random
+        x = if i < boundary_values.size
+              boundary_values[i]
+            elsif i.even?
+              rng.rand(p_val * p_val)
+            else
+              random_field_element(rng)
+            end
+        expect(s.fred(s.fred(x))).to eq(s.fred(x))
+      end
+    end
+
+    it 'fsqr consistency: fsqr(a) == fmul(a, a)' do
+      check_property('fsqr consistency') do |rng, i|
+        a = field_element(rng, i)
+        expect(s.fsqr(a)).to eq(s.fmul(a, a))
+      end
+    end
+
+    it 'fsqrt round-trip: if s = fsqrt(a^2), then s^2 == a^2' do
+      check_property('fsqrt round-trip') do |rng, i|
+        a = field_element(rng, i)
+        a_sq = s.fsqr(a)
+        root = s.fsqrt(a_sq)
+        expect(root).not_to be_nil, "fsqrt returned nil for a known quadratic residue (a=#{a})"
+        expect(s.fsqr(root)).to eq(a_sq)
+      end
+    end
+  end
 end

--- a/spec/secp256k1_property_spec.rb
+++ b/spec/secp256k1_property_spec.rb
@@ -197,4 +197,121 @@ RSpec.describe 'secp256k1 property-based tests', :property do # rubocop:disable 
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Scalar arithmetic properties (mod N)
+  # ---------------------------------------------------------------------------
+  describe 'scalar arithmetic' do # rubocop:disable Metrics/BlockLength
+    it 'scalar_mul is commutative: a*b == b*a' do
+      check_property('scalar_mul commutativity') do |rng, _i|
+        a = random_scalar(rng)
+        b = random_scalar(rng)
+        expect(s.scalar_mul(a, b)).to eq(s.scalar_mul(b, a))
+      end
+    end
+
+    it 'scalar_mul is associative: (a*b)*c == a*(b*c)' do
+      check_property('scalar_mul associativity') do |rng, _i|
+        a = random_scalar(rng)
+        b = random_scalar(rng)
+        c = random_scalar(rng)
+        expect(s.scalar_mul(s.scalar_mul(a, b), c)).to eq(s.scalar_mul(a, s.scalar_mul(b, c)))
+      end
+    end
+
+    it 'scalar_add is commutative: a+b == b+a' do
+      check_property('scalar_add commutativity') do |rng, _i|
+        a = random_scalar(rng)
+        b = random_scalar(rng)
+        expect(s.scalar_add(a, b)).to eq(s.scalar_add(b, a))
+      end
+    end
+
+    it 'scalar_add is associative: (a+b)+c == a+(b+c)' do
+      check_property('scalar_add associativity') do |rng, _i|
+        a = random_scalar(rng)
+        b = random_scalar(rng)
+        c = random_scalar(rng)
+        expect(s.scalar_add(s.scalar_add(a, b), c)).to eq(s.scalar_add(a, s.scalar_add(b, c)))
+      end
+    end
+
+    it 'multiplication distributes over addition: a*(b+c) == a*b + a*c' do
+      check_property('distributivity') do |rng, _i|
+        a = random_scalar(rng)
+        b = random_scalar(rng)
+        c = random_scalar(rng)
+        lhs = s.scalar_mul(a, s.scalar_add(b, c))
+        rhs = s.scalar_add(s.scalar_mul(a, b), s.scalar_mul(a, c))
+        expect(lhs).to eq(rhs)
+      end
+    end
+
+    it 'multiplicative inverse: a * a^-1 == 1 for non-zero a' do
+      check_property('multiplicative inverse') do |rng, _i|
+        a = random_scalar(rng)
+        expect(s.scalar_mul(a, s.scalar_inv(a))).to eq(1)
+      end
+    end
+
+    it 'scalar_mod is idempotent: scalar_mod(scalar_mod(a)) == scalar_mod(a)' do
+      # C extension rejects values exceeding 256 bits, so stay within [-N, 2^256)
+      max256 = (1 << 256) - 1
+      check_property('scalar_mod idempotence') do |rng, _i|
+        a = rng.rand((-n_val)..max256)
+        expect(s.scalar_mod(s.scalar_mod(a))).to eq(s.scalar_mod(a))
+      end
+    end
+
+    it 'scalar_mod result is always in [0, N)' do
+      max256 = (1 << 256) - 1
+      check_property('scalar_mod range') do |rng, _i|
+        a = rng.rand((-n_val)..max256)
+        result = s.scalar_mod(a)
+        expect(result).to be >= 0
+        expect(result).to be < n_val
+      end
+    end
+
+    # -----------------------------------------------------------------------
+    # Boundary values
+    # -----------------------------------------------------------------------
+    describe 'boundary values' do # rubocop:disable Metrics/BlockLength
+      it 'scalar_mul commutativity at boundaries' do
+        [1, n_val - 1, n_val - 2, n_val + 1].repeated_combination(2) do |a, b|
+          expect(s.scalar_mul(a, b)).to eq(s.scalar_mul(b, a))
+        end
+      end
+
+      it 'scalar_add commutativity at boundaries' do
+        [0, 1, n_val - 1, n_val - 2, n_val + 1].repeated_combination(2) do |a, b|
+          expect(s.scalar_add(a, b)).to eq(s.scalar_add(b, a))
+        end
+      end
+
+      it 'scalar_add of two values summing to exactly N yields 0' do
+        expect(s.scalar_add(1, n_val - 1)).to eq(0)
+        expect(s.scalar_add(n_val - 2, 2)).to eq(0)
+      end
+
+      it 'multiplicative inverse at boundaries' do
+        [1, n_val - 1, n_val - 2].each do |a|
+          expect(s.scalar_mul(a, s.scalar_inv(a))).to eq(1)
+        end
+      end
+
+      it 'scalar_inv(0) raises' do
+        expect { s.scalar_inv(0) }.to raise_error(ArgumentError)
+      end
+
+      it 'scalar_mod at boundaries' do
+        expect(s.scalar_mod(0)).to eq(0)
+        expect(s.scalar_mod(n_val)).to eq(0)
+        expect(s.scalar_mod(n_val - 1)).to eq(n_val - 1)
+        expect(s.scalar_mod(n_val + 1)).to eq(1)
+        expect(s.scalar_mod(-1)).to eq(n_val - 1)
+        expect(s.scalar_mod(-n_val)).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/secp256k1_property_spec.rb
+++ b/spec/secp256k1_property_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'secp256k1 property-based tests', :property do # rubocop:disable Metrics/BlockLength
+  include PropertyHelpers
+
+  let(:s) { Secp256k1 }
+  let(:p_val) { Secp256k1::P }
+  let(:n_val) { Secp256k1::N }
+
+  # ---------------------------------------------------------------------------
+  # Smoke test: verify the infrastructure itself works
+  # ---------------------------------------------------------------------------
+  describe 'infrastructure' do # rubocop:disable Metrics/BlockLength
+    it 'check_property runs the block the configured number of times' do
+      count = 0
+      check_property('counter', iterations: 50, seed: 1) do |_rng, _i|
+        count += 1
+      end
+      expect(count).to eq(50)
+    end
+
+    it 'check_property reports seed and iteration on failure' do
+      expect do
+        check_property('always fails', iterations: 3, seed: 0xBEEF) do |_rng, i|
+          raise 'boom' if i == 1
+        end
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /iteration 1.*seed: 0xbeef/i)
+    end
+
+    it 'generators produce values in the expected ranges' do
+      rng = Random.new(42)
+      fe = random_field_element(rng)
+      expect(fe).to be >= 0
+      expect(fe).to be < p_val
+
+      sc = random_scalar(rng)
+      expect(sc).to be >= 1
+      expect(sc).to be < n_val
+
+      pt = random_point(rng)
+      expect(pt).to be_a(Secp256k1::Point)
+      expect(pt.on_curve?).to be true
+    end
+
+    it 'PROPERTY_TEST_ITERATIONS env var is respected' do
+      # PropertyHelpers.iteration_count is used as the default — just verify
+      # it returns a positive integer.
+      expect(PropertyHelpers.iteration_count).to be_a(Integer)
+      expect(PropertyHelpers.iteration_count).to be_positive
+    end
+  end
+end

--- a/spec/secp256k1_property_spec.rb
+++ b/spec/secp256k1_property_spec.rb
@@ -314,4 +314,99 @@ RSpec.describe 'secp256k1 property-based tests', :property do # rubocop:disable 
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Point operation properties
+  # ---------------------------------------------------------------------------
+  describe 'point operations' do # rubocop:disable Metrics/BlockLength
+    let(:g) { Secp256k1::Point.generator }
+    let(:infinity) { Secp256k1::Point.infinity }
+
+    it 'identity: P + O = P' do
+      check_property('identity') do |rng, _i|
+        pt = random_point(rng)
+        expect(pt.add(infinity)).to eq(pt)
+        expect(infinity.add(pt)).to eq(pt)
+      end
+    end
+
+    it 'inverse: P + (-P) = O' do
+      check_property('inverse') do |rng, _i|
+        pt = random_point(rng)
+        expect(pt.add(pt.negate)).to eq(infinity)
+      end
+    end
+
+    it 'closure: P + Q is a valid curve point' do
+      check_property('closure') do |rng, _i|
+        pt = random_point(rng)
+        q = random_point(rng)
+        result = pt.add(q)
+        expect(result.on_curve?).to be(true)
+      end
+    end
+
+    it 'scalar multiplication homomorphism: k*G + m*G = (k+m)*G' do
+      check_property('scalar mul homomorphism', iterations: 200) do |rng, _i|
+        k = random_scalar(rng)
+        m = random_scalar(rng)
+        lhs = g.mul_vt(k).add(g.mul_vt(m))
+        rhs = g.mul_vt((k + m) % n_val)
+        expect(lhs).to eq(rhs)
+      end
+    end
+
+    it 'double consistency: P + P = 2*P (jp_add vs jp_double)' do
+      check_property('double consistency', iterations: 200) do |rng, _i|
+        pt = random_point(rng)
+        jp = [pt.x, pt.y, 1]
+        doubled_affine = s.jp_to_affine(s.jp_double(jp))
+        added_affine = s.jp_to_affine(s.jp_add(jp, jp))
+        expect(added_affine).to eq(doubled_affine)
+      end
+    end
+
+    it 'negation involution: -(-P) = P' do
+      check_property('negation involution') do |rng, _i|
+        pt = random_point(rng)
+        expect(pt.negate.negate).to eq(pt)
+      end
+    end
+
+    it 'mul/mul_vt parity: constant-time and variable-time give same result' do
+      check_property('mul/mul_vt parity') do |rng, _i|
+        k = random_scalar(rng)
+        expect(g.mul(k)).to eq(g.mul_vt(k))
+      end
+    end
+
+    it 'SEC1 round-trip: decode(encode(P)) = P for compressed' do
+      check_property('SEC1 compressed round-trip') do |rng, _i|
+        pt = random_point(rng)
+        encoded = pt.to_octet_string(:compressed)
+        decoded = Secp256k1::Point.from_bytes(encoded)
+        expect(decoded).to eq(pt)
+      end
+    end
+
+    it 'SEC1 round-trip: decode(encode(P)) = P for uncompressed' do
+      check_property('SEC1 uncompressed round-trip') do |rng, _i|
+        pt = random_point(rng)
+        encoded = pt.to_octet_string(:uncompressed)
+        decoded = Secp256k1::Point.from_bytes(encoded)
+        expect(decoded).to eq(pt)
+      end
+    end
+
+    it 'associativity: (P + Q) + R = P + (Q + R)' do
+      check_property('associativity', iterations: 100) do |rng, _i|
+        pt = random_point(rng)
+        q = random_point(rng)
+        r = random_point(rng)
+        lhs = pt.add(q).add(r)
+        rhs = pt.add(q.add(r))
+        expect(lhs).to eq(rhs)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 require 'secp256k1'
+
+Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }

--- a/spec/support/property_helpers.rb
+++ b/spec/support/property_helpers.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Lightweight property-based testing helpers for secp256k1.
+#
+# Provides a +check_property+ method that runs a block many times with a
+# deterministic local RNG, reporting the seed, iteration index, and specific
+# inputs on failure.  Generators produce random field elements, scalars, and
+# curve points suitable for algebraic law verification.
+#
+# Iteration count defaults to 1,000 and can be overridden with the
+# +PROPERTY_TEST_ITERATIONS+ environment variable.
+module PropertyHelpers
+  # Default number of iterations per property.
+  DEFAULT_ITERATIONS = 1_000
+
+  # Parse the environment override once.  Non-numeric values are silently
+  # ignored and the default is used instead.
+  def self.iteration_count
+    raw = ENV.fetch('PROPERTY_TEST_ITERATIONS', nil)
+    return DEFAULT_ITERATIONS if raw.nil? || raw.strip.empty?
+
+    parsed = Integer(raw, exception: false)
+    parsed&.positive? ? parsed : DEFAULT_ITERATIONS
+  end
+
+  # Run a property check.
+  #
+  # @param name [String]   human-readable property description (used in
+  #   failure messages)
+  # @param iterations [Integer]  how many random inputs to test
+  # @param seed [Integer]  deterministic seed for +Random.new+
+  # @yield [rng, index]  block that should raise or call +expect+ on failure
+  # @yieldparam rng [Random]  seeded local RNG — use this, not +Kernel.rand+
+  # @yieldparam index [Integer]  zero-based iteration index
+  def check_property(name, iterations: PropertyHelpers.iteration_count, seed: 0xC0FFEE, &block)
+    rng = Random.new(seed)
+
+    iterations.times do |i|
+      block.call(rng, i)
+    rescue RSpec::Expectations::ExpectationNotMetError, StandardError => e
+      raise RSpec::Expectations::ExpectationNotMetError,
+            "Property '#{name}' failed on iteration #{i} (seed: 0x#{seed.to_s(16)}): #{e.message}"
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Generators
+  # -------------------------------------------------------------------------
+
+  # Random field element in [0, P).
+  def random_field_element(rng)
+    rng.rand(Secp256k1::P)
+  end
+
+  # Random non-zero field element in [1, P).
+  def random_nonzero_field_element(rng)
+    1 + rng.rand(Secp256k1::P - 1)
+  end
+
+  # Random scalar in [1, N).  Zero is excluded because most scalar
+  # properties (inverse, multiplication) are undefined or trivial at zero.
+  def random_scalar(rng)
+    1 + rng.rand(Secp256k1::N - 1)
+  end
+
+  # Random curve point, generated as k*G for a random scalar k.
+  def random_point(rng)
+    Secp256k1::Point.generator.mul_vt(random_scalar(rng))
+  end
+end


### PR DESCRIPTION
## Summary
- Add property-based test infrastructure with deterministic seeding and configurable iterations (`PROPERTY_TEST_ITERATIONS` env var)
- Test 14 field arithmetic properties (commutativity, associativity, distributivity, identity, inverse, negation involution, subtraction definition, reduction idempotence, fsqr/fsqrt consistency)
- Test 14 scalar arithmetic properties with explicit boundary value coverage (N, N-1, N+1, sum-to-N edge cases)
- Test 10 point operation properties (group law, scalar mul homomorphism, mul/mul_vt parity, SEC1 round-trip, associativity)
- Verify all 16 C extension methods produce identical results to pure-Ruby implementations (cross-implementation parity)
- 58 new property-based test examples tagged `:property`, each running 100-1,000 random iterations

## Test plan
- [x] All 368 examples pass (`bundle exec rspec`)
- [x] Property tests selectively runnable (`bundle exec rspec --tag property`)
- [x] RuboCop clean on new files
- [x] Acceptance criteria verified for all 6 sub-issues (#3-#8)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
