### PR TITLE
feat: Copilot review instructions + security/ harness hardening

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,83 @@
+# Copilot code review — secp256k1-native
+
+Cryptographic primitives library. Pure-Ruby reference (`lib/secp256k1.rb`) + optional C extension in `ext/secp256k1_native/` for constant-time hardening of 16 hot-path methods. The C extension exists for security, not speed.
+
+## Conventions to know
+
+- `uint256_t` = 4 × `uint64_t` little-endian limbs; `d[0]` is least-significant.
+- Field modulus `P = 2^256 − 2^32 − 977`. Curve order `N`. Distinct.
+- `Point#mul` (alias `mul_ct`) — Montgomery ladder, constant-time, default; OK for secret scalars.
+- `Point#mul_vt` — wNAF, variable-time, **public scalars only**.
+- Jacobian repr `[X, Y, Z]`. Infinity = `[0, 1, 0]`.
+
+## Carry propagation (in `field.c`)
+
+- Carry/borrow must propagate through all four limbs after each add/sub/mul/reduce. Flag suppression, masking, or early termination of the chain.
+- Fast-reduction folds the high half via `FRED_C = 0x1000003D1` (= `2^32 + 977`). The folded high-word carry must be re-propagated in a second pass.
+- Flag any narrowing of `__uint128_t` to `uint64_t` that drops the high half without absorbing it into carry.
+
+## Canonicalisation
+
+- Field outputs must lie in `[0, P)`. Flag any path that can return a value in `[P, 2P)` — the final conditional subtraction is load-bearing.
+- Scalar outputs from `scalar_*` must lie in `[0, N)`.
+- SEC1: compressed = 33 B (`0x02`/`0x03` prefix); uncompressed = 65 B (`0x04` prefix). Reject anything else.
+
+## Point validation
+
+- Compressed-point parsing must verify `Y² ≡ X³ + 7 (mod P)` before accepting reconstructed `Y`.
+- Reject off-curve points and `Y = 0` at boundaries that don't admit the identity.
+- Zero/identity points in Jacobian form must be `[0, 1, 0]`, not `[0, 0, 0]`.
+- `jp_add_internal` is fully branchless: `P == Q` and `P == −Q` are handled via mask-based `uint256_select` over an unconditional inline `jp_double`. Flag any regression to a branching implementation — the earlier branching version measured |t| = 875 timing leakage.
+
+## Modulus confusion
+
+- Field code is `mod P`. Scalar code is `mod N`. Flag `mod P` on scalar paths or `mod N` on field paths.
+- Fermat inverse exponents: field uses `P − 2`, scalar uses `N − 2`.
+- Reject `0` and `≥ N` scalars at API boundaries; do not silently reduce.
+
+## Constant-time (secret-scalar paths)
+
+Secret-scalar paths: `Point#mul`, `scalar_multiply_ct`, `scalar_mul`, `scalar_inv`. On these paths, flag:
+
+- `if` / `switch` / `?:` / short-circuit `&&` `||` / early `return` `break` `continue` whose taken-ness depends on secret data.
+- Variable-time C operators on secret data: `/`, `%`, variable-count shifts.
+- Array/table indexing where the index is secret-derived (cache-timing leak).
+- `memcmp` / `==` / `strcmp` on secret-derived buffers — require a constant-time compare.
+- Loops whose iteration count depends on secret data. The Montgomery ladder is fixed at 256 iterations.
+- Hand-rolled branchless code that ignores `cswap` (in `jacobian.c`) and `uint256_select` (in `secp256k1_native.h`).
+
+Flag CT-critical changes (to `fred`, `fsub`, `fneg`, `fadd`, `scalar_multiply_ct`, `cswap`, `jp_add_internal`, `jp_double_internal`, or the Montgomery ladder body) that don't update timing-test coverage.
+
+## API safety contract
+
+- New secret-scalar code paths must call `mul`, not `mul_vt`.
+- Variable-time methods must be `_vt`-suffixed with a doc comment stating the public-scalar precondition.
+- No silent C→pure-Ruby fallback on secret-scalar paths. Bypassing both `SECP256K1_ALLOW_PURE_RUBY_CT` and `Secp256k1.allow_pure_ruby_ct!` is a regression.
+
+## C extension memory safety
+
+- `malloc`/`calloc`/`realloc`/`free` anywhere in `ext/secp256k1_native/` — there should be none.
+- Manual byte shuffling instead of `rb_integer_pack` / `rb_integer_unpack`.
+- Decoding `Integer` inputs without bounds-checking (> 256 bits, wrong sign) — must raise, not truncate.
+- Plain `memset` of secret material in a stack buffer about to leave scope. Compiler may elide; use a volatile-cast write or explicit barrier.
+- Compiler-specific intrinsics without an `extconf.rb` gate or fallback.
+
+## State management
+
+- New module-level mutable `Hash` / `Array` / `Set` without `mul_vt`-only confinement or a mutex. `WNAF_TABLE_CACHE` is the only one; it is confined to public-scalar paths.
+
+## Tests
+
+- Field / scalar / point changes without RSpec additions in `spec/`.
+- Asymmetric edits to pure-Ruby vs C — `spec/secp256k1_cross_property_spec.rb` requires they agree.
+- Invalid inputs (zero or out-of-range scalars, off-curve points, malformed SEC1) that don't raise the expected exception type.
+
+## Do not flag
+
+- Variable-time operations inside `mul_vt` / wNAF table code / wNAF cache. Explicitly public-scalar.
+- Single-letter parameter names (`k`, `p`, `x`, `y`, `z`, `n`, `r`, `s`, `h`). Curve-notation convention.
+- `__uint128_t`, GCC/Clang-specific intrinsics gated by `extconf.rb`, C99 features.
+- `# frozen_string_literal: true`, Ruby 2.7 syntax. Rubocop enforces.
+- Pure-Ruby's lack of constant-time guarantees. Documented and gated.
+- `Point#mul_vt` and the `mul_ct` alias. Intentional.
+- 16-method replacement at C extension load. Intentional architecture.

--- a/security/Makefile
+++ b/security/Makefile
@@ -39,11 +39,17 @@ asan: asan_sweep.c $(EXT_SRCS) $(STUB_SRC)
 	$(CC) -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer \
 	      $(BASEFLAGS) $^ -lm -o asan_sweep
 
-# Smoke run: build all, run a short pass of each.
-check: all
+# Smoke run: build what we can, run a short pass of each.
+# ctgrind builds against <valgrind/memcheck.h>, so we build it lazily — only
+# when valgrind is present. That keeps `make check` clean on native macOS.
+check: dfuzz asan
 	@echo "== differential fuzz vs independent Python reference ==" ; python3 dfuzz_ref.py
 	@echo "== ctgrind (valgrind memcheck) — flags the I-11 scalar branches until fixed ==" ; \
-	  valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness 2>&1 | tail -3 || true
+	  if command -v valgrind >/dev/null 2>&1; then \
+	    $(MAKE) -s ctgrind && valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness 2>&1 | tail -3 || true; \
+	  else \
+	    echo "  SKIP: valgrind not present — see ./run-checks.sh"; \
+	  fi
 	@echo "== asan/ubsan sweep ==" ; \
 	  UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./asan_sweep 2>&1 | tail -3
 

--- a/security/Makefile
+++ b/security/Makefile
@@ -45,10 +45,12 @@ asan: asan_sweep.c $(EXT_SRCS) $(STUB_SRC)
 check: dfuzz asan
 	@echo "== differential fuzz vs independent Python reference ==" ; python3 dfuzz_ref.py
 	@echo "== ctgrind (valgrind memcheck) — flags the I-11 scalar branches until fixed ==" ; \
-	  if command -v valgrind >/dev/null 2>&1; then \
-	    $(MAKE) -s ctgrind && valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness 2>&1 | tail -3 || true; \
-	  else \
+	  if ! command -v valgrind >/dev/null 2>&1; then \
 	    echo "  SKIP: valgrind not present — see ./run-checks.sh"; \
+	  elif ! $(MAKE) -s ctgrind; then \
+	    echo "  FAIL: ctgrind harness build failed"; \
+	  else \
+	    valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness 2>&1 | tail -3 || true; \
 	  fi
 	@echo "== asan/ubsan sweep ==" ; \
 	  UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./asan_sweep 2>&1 | tail -3

--- a/security/README.md
+++ b/security/README.md
@@ -29,9 +29,11 @@ make check                                       # build + short smoke of all th
 make clean
 ```
 
-`dfuzz_ref.py` exits non-zero if any *in-contract* case mismatches, and prints
-which of the four known-defect regression vectors still diverge — so it doubles
-as a CI gate that flips green the moment the H-1/M-1 fixes land.
+`dfuzz_ref.py` exits non-zero only if an *in-contract* case mismatches — that's
+its CI-gate role. The four known-defect regression vectors are exercised on
+every run and any divergence is printed for visibility; they do **not** affect
+the exit code, so the gate is already green against the reviewed v1.0 tree.
+When the H-1/M-1 fixes land, those divergence prints will simply disappear.
 
 ## Expected results (against the reviewed v1.0 tree)
 

--- a/security/dfuzz_harness.c
+++ b/security/dfuzz_harness.c
@@ -35,6 +35,11 @@ int main(void) {
     char h[8][80];
     uint256_t a, b, k;
     while (fgets(line, sizeof(line), stdin)) {
+        /* Zero h[] each iteration so any sscanf slot left unmatched by a
+         * short input line reads as an empty string rather than uninitialised
+         * stack. hex_to_u256("") returns the all-zero u256 — the per-op
+         * result will be wrong, but the harness will not crash. */
+        memset(h, 0, sizeof h);
         int n = sscanf(line, "%31s %79s %79s %79s %79s %79s %79s %79s",
                        op, h[0], h[1], h[2], h[3], h[4], h[5], h[6]);
         if (n < 1) continue;

--- a/security/run-checks.sh
+++ b/security/run-checks.sh
@@ -16,6 +16,10 @@ cd "$(dirname "$0")"
 # Smoke default is modest so the gate is fast; scale up for a thorough run,
 # e.g. ITERS=2000000 ./run-checks.sh
 ITERS="${ITERS:-20000}"
+# Pre-#21 state: ctgrind reports the documented I-11 secret-dependent branches
+# in scalar_reduce_limbs; that's expected and reported as "KNOWN", not "FAIL".
+# Set EXPECT_I11=0 once #21 lands so any valgrind diagnostic counts as FAIL.
+EXPECT_I11="${EXPECT_I11:-1}"
 rc=0
 
 echo "== differential fuzz vs independent reference (${ITERS} iters/op-class) =="
@@ -33,18 +37,18 @@ else
 fi
 
 echo "== ctgrind secret-poisoning (valgrind) =="
-if command -v valgrind >/dev/null 2>&1; then
-  make -s ctgrind
-  if valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness >/dev/null 2>&1; then
-    echo "  PASS: 0 errors (no secret-dependent control flow)"
-  else
-    # Expected to report the I-11 scalar_reduce_limbs branches until #21 lands.
-    echo "  KNOWN: secret-dependent branches reported — expected until #21 (I-11) is fixed"
-  fi
-else
+if ! command -v valgrind >/dev/null 2>&1; then
   echo "  SKIP: valgrind not present (native macOS) — run this gate via the Docker image"
+elif ! make -s ctgrind; then
+  echo "  FAIL: ctgrind harness build failed"; rc=1
+elif valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness >/dev/null 2>&1; then
+  echo "  PASS: 0 errors (no secret-dependent control flow)"
+elif [ "$EXPECT_I11" = "1" ]; then
+  echo "  KNOWN: secret-dependent branches reported — expected until #21 (I-11) is fixed"
+else
+  echo "  FAIL: valgrind reported errors (re-run ./ctgrind_harness under valgrind to see them)"; rc=1
 fi
 
 echo
-echo "overall: $([ $rc -eq 0 ] && echo PASS || echo FAIL) (ctgrind 'KNOWN' is not a failure pre-#21)"
+echo "overall: $([ $rc -eq 0 ] && echo PASS || echo FAIL) (ctgrind 'KNOWN' is not a failure while EXPECT_I11=1)"
 exit $rc


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` (748 words) so Copilot PR code review focuses on the cryptographic patterns that matter here: carry propagation, canonicalisation, point validation, modulus (P vs N), constant-time on secret-scalar paths, C extension memory safety, the safe-by-default API contract, cross-implementation parity, and tests. Includes a "do not flag" section to keep noise out.
- Hardens `security/` tooling against the four findings Copilot caught on #20 but we merged past: ctgrind error masking, Makefile `make check` UX on macOS, README CI-gate claim that didn't match the script, and a UB risk in `dfuzz_harness.c` on short input.

Five small commits, one per item, all with `Refs #26`.

## Test plan

- [x] `make -n check` shows the expected sequence (dfuzz/asan deps, lazy ctgrind, conditional valgrind invocation).
- [x] `ITERS=500 make check` on macOS (no valgrind): dfuzz green, ctgrind "SKIP" message fires, asan proceeds.
- [x] `printf 'fmul deadbeef\nfsqr\n' | ./dfuzz` returns two zero results and exits 0 — previously read uninitialised stack.
- [x] `bash -n security/run-checks.sh` passes; the four-outcome ctgrind block reviewed for correctness on each branch (no valgrind → SKIP; build fail → FAIL; valgrind 0 → PASS; valgrind ≠0 & `EXPECT_I11=1` → KNOWN; valgrind ≠0 & `EXPECT_I11=0` → FAIL).
- [x] `wc -w .github/copilot-instructions.md` = 748 (under GitHub's 1,000-word guideline).
- [ ] On Linux/Docker, confirm `make check` still runs ctgrind under valgrind (unchanged path on systems that have it).

## Notes

- Copilot reads instructions from the **base branch**, so this PR will **not** be reviewed under its own rules — the file's effect starts on the next PR after this one merges.
- `EXPECT_I11` defaults to `1` to match the current pre-#21 state. The #21-landing PR should flip the default (or remove the variable) so `run-checks.sh` no longer masks valgrind diagnostics by default.

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)