### PR TITLE
fix: scalar reduction carry — H-1 / I-2 / I-11 (v1 blocker)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,12 @@ The field operations `fred`, `fsub`, `fneg`, and `fadd` use branchless condition
 
 Inversion (`finv`) and square root (`fsqrt`) iterate over public constants (P-2 and (P+1)/4 respectively). Since the exponents are not secret, the variable iteration pattern is safe.
 
+### Scalar arithmetic
+
+The scalar operations `scalar_mul_internal`, `scalar_reduce`, and `scalar_add_internal` use branchless conditional selection — bitwise masks from carry/borrow flags and a captured topcarry — with no operand-dependent control flow. After the #21 fix, `scalar_reduce_limbs` is fully branchless: the previous `if (h == 0) continue` and `if (carry3)` guards in the residual fold were removed (the second-fold loop body is a faithful no-op when `h == 0`; the residual fold is now unconditional with topcarry capture, replacing the dropped-carry tail that caused H-1).
+
+`scalar_inv_internal` iterates over bits of the public constant N-2 via Fermat's little theorem. The branch on each bit is over public data; the per-iteration `scalar_mul_internal` operates on the secret base and is branchless.
+
 ### Montgomery ladder
 
 The C extension implements the Montgomery ladder with a branchless conditional swap (`cswap`) using bitwise masking — no branch on the scalar bit. Both `cswap` and `jp_add_internal` are fully branchless: all input-dependent special cases (infinity checks, equal/negated point detection) are handled via mask-based `uint256_select` rather than conditional branches. This provides genuine constant-time scalar multiplication at the C level, with fixed 256 iterations regardless of scalar value.
@@ -78,6 +84,16 @@ The C extension's constant-time claims are empirically tested using a dudect-bas
 | `fsub_internal` | 0.1–1.0 | 1,500,000 | PASS |
 | `fneg_internal` | 0.1–1.3 | 1,500,000 | PASS |
 | `fadd_internal` | 0.1–3.4 | 1,500,000 | PASS |
+
+**Scalar arithmetic — verified constant-time (#21):**
+
+| Function | |t| | Measurements | Result |
+|---|---|---|---|
+| `scalar_mul_internal` | 1.0 | 1,000,000 | PASS |
+| `scalar_reduce` | 0.7 | 1,000,000 | PASS |
+| `scalar_inv_internal` | 0.2 | 1,000 | PASS |
+
+After the #21 fix, `scalar_reduce_limbs` is fully branchless. The previous I-11 finding (secret-dependent branches on `h == 0` and `carry3` in the residual fold) is closed; ctgrind reports `0 errors` on the scalar layer. The dudect tests above empirically corroborate this on the dev hardware used to verify the fix.
 
 **Point operations — verified constant-time:**
 

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -28,9 +28,9 @@
  *
  * Constant-time discipline
  * ------------------------
- * scalar_reduce, scalar_add_internal use branchless conditional selection.
- * scalar_inv_internal iterates over bits of the public constant N-2, which
- * is safe.
+ * scalar_reduce_limbs and scalar_add_internal use branchless conditional
+ * selection — no operand-dependent branches in either.  scalar_inv_internal
+ * iterates over bits of the public constant N-2, which is safe.
  */
 
 /* -----------------------------------------------------------------------
@@ -90,11 +90,16 @@ static const uint256_t SCALAR_ONE = {{ 1ULL, 0ULL, 0ULL, 0ULL }};
  * After the first fold the 512-bit value has been reduced to at most
  * ~385 bits.  The overflow above bit 255 (stored in the temporary carry
  * words) requires a second fold.  After two folds the result fits in
- * 256 bits + at most 1 bit, handled by a conditional subtraction.
+ * 256 bits + at most 1 bit; the residual fold then propagates that
+ * remaining bit (the "topcarry") and a branchless conditional-subtract of N
+ * selects whichever of {r, r-N} is the canonical residue.  When topcarry is
+ * set, the subtract also folds the dropped 2^256 back as c_N (= 2^256 - N).
  *
  * We accumulate into an 8-limb array and reuse the upper limbs as
  * temporaries for the folded-in contributions, so no extra allocation is
  * needed.
+ *
+ * Branchless throughout — no operand-dependent control flow.
  */
 static void scalar_reduce_limbs(uint256_t *r, uint64_t product[8])
 {
@@ -161,9 +166,12 @@ static void scalar_reduce_limbs(uint256_t *r, uint64_t product[8])
     uint64_t hi2[4];
     for (i = 0; i < 4; i++) { hi2[i] = t[4 + i]; t[4 + i] = 0; }
 
+    /* Second fold — unconditional loop body (no branch on h being zero).
+     * The body is a faithful no-op when h == 0 (each `h * CONST` term is 0
+     * and the carries propagate identically), so removing the guard changes
+     * no result, only the timing.  (Closes I-11 secret-dependent branch.) */
     for (i = 0; i < 4; i++) {
         uint64_t h = hi2[i];
-        if (h == 0) continue;
 
         acc       = (uint128_t)h * CN_LO + t[i];
         t[i]      = (uint64_t)acc;
@@ -183,30 +191,44 @@ static void scalar_reduce_limbs(uint256_t *r, uint64_t product[8])
         /* After two folds, any carry here is negligible (< 2). */
     }
 
-    /* The result is now in t[0..3] with at most a tiny overflow in t[4].
-     * Copy t[0..3] into r and apply a conditional subtraction. */
+    /* Result is now in t[0..3] with at most a 1-bit residual carry in t[4].
+     *
+     * Invariant: t[4] <= 1 here.  Why: after the first fold the value is
+     * < 2^385 (max ~129 bits above bit 255).  The second fold reduces that
+     * overflow by another factor of c_N ≈ 2^129, so the residual after the
+     * second fold is < 2^257, i.e. fits in 256 bits + at most 1 bit. */
     r->d[0] = t[0]; r->d[1] = t[1]; r->d[2] = t[2]; r->d[3] = t[3];
 
-    /* Handle residual overflow from t[4] (at most 1 after two folds of
-     * a 512-bit input): add t[4] × c_N into r. */
+    /* Residual fold — unconditional (I-11: no branch on the carry) and
+     * capturing the carry OUT of the top limb (H-1: previously dropped at
+     * bit 255).  After two folds the value here is < 2^257, so topcarry
+     * is 0 or 1. */
     uint64_t carry3 = t[4];
-    if (carry3) {
-        /* carry3 is at most a few bits wide — use simple arithmetic. */
-        uint128_t a0 = (uint128_t)carry3 * CN_LO + r->d[0];
-        r->d[0] = (uint64_t)a0;
-        uint128_t a1 = (uint128_t)carry3 * CN_MID + r->d[1] + (a0 >> 64);
-        r->d[1] = (uint64_t)a1;
-        uint128_t a2 = (uint128_t)carry3 + r->d[2] + (a1 >> 64);
-        r->d[2] = (uint64_t)a2;
-        r->d[3] += (uint64_t)(a2 >> 64);
-    }
+    uint128_t a0 = (uint128_t)carry3 * CN_LO + r->d[0];
+    r->d[0] = (uint64_t)a0;
+    uint128_t a1 = (uint128_t)carry3 * CN_MID + r->d[1] + (a0 >> 64);
+    r->d[1] = (uint64_t)a1;
+    uint128_t a2 = (uint128_t)carry3 + r->d[2] + (a1 >> 64);
+    r->d[2] = (uint64_t)a2;
+    uint128_t a3 = (uint128_t)r->d[3] + (a2 >> 64);
+    r->d[3] = (uint64_t)a3;
+    uint64_t topcarry = (uint64_t)(a3 >> 64);    /* 0 or 1 — was H-1 dropped bit */
 
-    /* Branchless final conditional subtraction: keep r - N if r >= N. */
+    /* Branchless final reduction: keep (r - N) when topcarry is set OR r >= N.
+     *
+     * c_N == 2^256 - N, so subtracting N once when topcarry is set converts
+     * the dropped 2^256 into the correct +c_N residue.  Total value V < 2N
+     * (from V < 2^257 and N ≈ 2^256), so a single conditional subtract of N
+     * is sufficient.
+     *
+     * Using (1 ^ borrow) instead of (borrow == 0) avoids any compiler
+     * latitude to emit a compare-and-branch for the predicate. */
     uint256_t reduced;
-    uint64_t borrow = uint256_sub(&reduced, r, &CURVE_N);
-    uint64_t mask = -(uint64_t)(borrow != 0); /* all 1s if r < N */
+    uint64_t borrow = uint256_sub(&reduced, r, &CURVE_N);   /* borrow==0 <=> r >= N */
+    uint64_t keep_reduced = topcarry | (1 ^ borrow);
+    uint64_t mask = -(uint64_t)(keep_reduced != 0);
     for (i = 0; i < 4; i++) {
-        r->d[i] = (r->d[i] & mask) | (reduced.d[i] & ~mask);
+        r->d[i] = (reduced.d[i] & mask) | (r->d[i] & ~mask);
     }
 }
 

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -382,8 +382,18 @@ static VALUE rb_scalar_mul(VALUE self, VALUE a, VALUE b)
     (void)self;
     uint256_t ua = rb_to_uint256(a);
     uint256_t ub = rb_to_uint256(b);
+
+    /* Defence in depth: pre-reduce both operands mod N before multiplying.
+     * scalar_mul_internal is correct on any 256-bit operand pair after the
+     * H-1 fix, so this is belt-and-braces — but it makes the Ruby boundary's
+     * input contract explicit and consistent with rb_scalar_inv. */
+    uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
+    uint256_t ua_reduced, ub_reduced;
+    scalar_reduce(&ua_reduced, &zero_limbs, &ua);
+    scalar_reduce(&ub_reduced, &zero_limbs, &ub);
+
     uint256_t r;
-    scalar_mul_internal(&r, &ua, &ub);
+    scalar_mul_internal(&r, &ua_reduced, &ub_reduced);
     return uint256_to_rb(&r);
 }
 

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -191,12 +191,14 @@ static void scalar_reduce_limbs(uint256_t *r, uint64_t product[8])
         /* After two folds, any carry here is negligible (< 2). */
     }
 
-    /* Result is now in t[0..3] with at most a 1-bit residual carry in t[4].
+    /* Result is now in t[0..3] with a small residual in t[4].
      *
-     * Invariant: t[4] <= 1 here.  Why: after the first fold the value is
-     * < 2^385 (max ~129 bits above bit 255).  The second fold reduces that
-     * overflow by another factor of c_N ≈ 2^129, so the residual after the
-     * second fold is < 2^257, i.e. fits in 256 bits + at most 1 bit. */
+     * Bound: after the first fold the value is < 2^386 (the original 512-bit
+     * product reduced by c_N ≈ 2^129).  The second fold reduces that overflow
+     * by another factor of c_N, so the post-second-fold residual is < 2^259
+     * — i.e. t[4] is a few bits wide (at most a small single-digit value),
+     * and the residual fold below produces V < 2N.  V < 2N means a single
+     * conditional subtract of N is sufficient to canonicalise. */
     r->d[0] = t[0]; r->d[1] = t[1]; r->d[2] = t[2]; r->d[3] = t[3];
 
     /* Residual fold — unconditional (I-11: no branch on the carry) and

--- a/security/ctgrind_harness.c
+++ b/security/ctgrind_harness.c
@@ -161,9 +161,9 @@ int main(void)
      *    N-2 so branching there is expected/safe — but the squaring/mul it
      *    calls operate on secret data, so we still test scalar_mul.
      *
-     *    NOTE: scalar_reduce_limbs contains `if (h == 0) continue;` on
-     *    data derived from the operands. If h is secret-derived this is a
-     *    secret-dependent branch — this test will catch it.
+     *    Post-#21, scalar_reduce_limbs is fully branchless — the previous
+     *    `if (h == 0) continue;` and `if (carry3)` guards in the residual
+     *    fold were removed.  This test confirms 0 errors on the scalar layer.
      * ------------------------------------------------------------------ */
     {
         uint256_t a, b, r;

--- a/security/run-checks.sh
+++ b/security/run-checks.sh
@@ -16,10 +16,6 @@ cd "$(dirname "$0")"
 # Smoke default is modest so the gate is fast; scale up for a thorough run,
 # e.g. ITERS=2000000 ./run-checks.sh
 ITERS="${ITERS:-20000}"
-# Pre-#21 state: ctgrind reports the documented I-11 secret-dependent branches
-# in scalar_reduce_limbs; that's expected and reported as "KNOWN", not "FAIL".
-# Set EXPECT_I11=0 once #21 lands so any valgrind diagnostic counts as FAIL.
-EXPECT_I11="${EXPECT_I11:-1}"
 rc=0
 
 echo "== differential fuzz vs independent reference (${ITERS} iters/op-class) =="
@@ -43,12 +39,10 @@ elif ! make -s ctgrind; then
   echo "  FAIL: ctgrind harness build failed"; rc=1
 elif valgrind --tool=memcheck --error-exitcode=1 ./ctgrind_harness >/dev/null 2>&1; then
   echo "  PASS: 0 errors (no secret-dependent control flow)"
-elif [ "$EXPECT_I11" = "1" ]; then
-  echo "  KNOWN: secret-dependent branches reported — expected until #21 (I-11) is fixed"
 else
   echo "  FAIL: valgrind reported errors (re-run ./ctgrind_harness under valgrind to see them)"; rc=1
 fi
 
 echo
-echo "overall: $([ $rc -eq 0 ] && echo PASS || echo FAIL) (ctgrind 'KNOWN' is not a failure while EXPECT_I11=1)"
+echo "overall: $([ $rc -eq 0 ] && echo PASS || echo FAIL)"
 exit $rc

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -344,6 +344,12 @@ RSpec.describe 'Secp256k1Native' do
     # value wrong by exactly c_N and still in [0, N). Random testing cannot
     # reach H-1's band (density ~2^-384) — this structured vector is
     # load-bearing.
+    #
+    # Note on scope: rb_scalar_mul (post-#21 defence-in-depth) pre-reduces
+    # operands, so this assertion exercises end-to-end correctness — not the
+    # H-1 path through scalar_mul_internal directly. The primitive itself is
+    # covered by security/dfuzz_harness.c's smul op (called from
+    # dfuzz_ref.py), which calls scalar_mul_internal with no Ruby wrapper.
     it 'is correct for (2^256-1) * (N+2) [H-1 carry-drop regression]' do
       a = (1 << 256) - 1
       b = curve_n + 2

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -356,12 +356,17 @@ RSpec.describe 'Secp256k1Native' do
       expect(n.scalar_mul(a, b)).to eq((a * b) % curve_n)
     end
 
-    it 'is correct for (2^256-1) * (2^256-1) [worst-case 512-bit product]' do
+    # Like the H-1 test above, the next two assertions exercise end-to-end
+    # behaviour through rb_scalar_mul, which post-#21 defence-in-depth
+    # pre-reduces operands.  scalar_mul_internal therefore sees the reduced
+    # values, not the literals in the test labels.  The primitive's direct
+    # coverage comes from security/dfuzz_harness.c (smul op).
+    it 'is correct for (2^256-1) * (2^256-1) end-to-end [reduced to (c_N-1)^2]' do
       a = (1 << 256) - 1
       expect(n.scalar_mul(a, a)).to eq((a * a) % curve_n)
     end
 
-    it 'is correct for N * N [non-canonical squaring]' do
+    it 'reduces N to 0 in rb_scalar_mul defence-in-depth (N * N -> 0)' do
       expect(n.scalar_mul(curve_n, curve_n)).to eq(0)
     end
   end

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -291,6 +291,20 @@ RSpec.describe 'Secp256k1Native' do
       expect(n.scalar_mod(curve_n + 1)).to eq(1)
     end
 
+    it 'returns 2 for input N+2' do
+      expect(n.scalar_mod(curve_n + 2)).to eq(2)
+    end
+
+    # Boundary band: values close to but under 2^256 exercise scalar_reduce's
+    # final conditional subtract on hi=0, lo near the top of the 256-bit range.
+    # rb_scalar_mod rejects values >= 2^256, so 2*N etc. cannot be tested here
+    # — see the dfuzz harness for the hi != 0 case.
+    it 'matches Integer#% for boundary values up to 2^256 - 1' do
+      [curve_n + 2, curve_n + 100, (1 << 256) - 2, (1 << 256) - 1].each do |x|
+        expect(n.scalar_mod(x)).to eq(x % curve_n), "x=#{x}"
+      end
+    end
+
     it 'matches the Ruby reference for a typical value' do
       expect(n.scalar_mod(gx)).to eq(ref.scalar_mod(gx))
     end
@@ -324,6 +338,26 @@ RSpec.describe 'Secp256k1Native' do
       b = gy % curve_n
       expect(n.scalar_mul(a, b)).to eq(ref.scalar_mul(a, b))
     end
+
+    # H-1 regression: pre-fix, scalar_reduce_limbs dropped the carry out of
+    # bit 255 in the residual fold, so scalar_mul(2^256-1, N+2) returned a
+    # value wrong by exactly c_N and still in [0, N). Random testing cannot
+    # reach H-1's band (density ~2^-384) — this structured vector is
+    # load-bearing.
+    it 'is correct for (2^256-1) * (N+2) [H-1 carry-drop regression]' do
+      a = (1 << 256) - 1
+      b = curve_n + 2
+      expect(n.scalar_mul(a, b)).to eq((a * b) % curve_n)
+    end
+
+    it 'is correct for (2^256-1) * (2^256-1) [worst-case 512-bit product]' do
+      a = (1 << 256) - 1
+      expect(n.scalar_mul(a, a)).to eq((a * a) % curve_n)
+    end
+
+    it 'is correct for N * N [non-canonical squaring]' do
+      expect(n.scalar_mul(curve_n, curve_n)).to eq(0)
+    end
   end
 
   describe '#scalar_inv' do
@@ -350,6 +384,23 @@ RSpec.describe 'Secp256k1Native' do
     it 'matches the Ruby reference' do
       a = gx % curve_n
       expect(n.scalar_inv(a)).to eq(ref.scalar_inv(a))
+    end
+
+    # Fermat ladder consistency: scalar_inv runs ~256 scalar_mul_internal
+    # calls on intermediate values that exercise scalar_reduce_limbs broadly,
+    # including operand combinations that pre-H-1 could trip the dropped-
+    # carry case. Confirms x * inv(x) ≡ 1 holds across the Fermat loop.
+    it 'satisfies x * inv(x) ≡ 1 across several adversarial x' do
+      [
+        2,
+        (1 << 255),
+        curve_n - 1,
+        curve_n + 2,        # non-canonical; rb_scalar_inv pre-reduces
+        (1 << 256) - 1      # non-canonical max 256-bit value
+      ].each do |x|
+        inv = n.scalar_inv(x)
+        expect(n.scalar_mul(x, inv)).to eq(1), "x=#{x}"
+      end
     end
   end
 

--- a/timing/timing_harness.c
+++ b/timing/timing_harness.c
@@ -120,6 +120,18 @@ static const uint256_t FIELD_P = {{
 }};
 
 /* -----------------------------------------------------------------------
+ * secp256k1 curve order N
+ * Little-endian limb order (d[0] = least-significant 64 bits).
+ * ----------------------------------------------------------------------- */
+
+static const uint256_t CURVE_N = {{
+    0xBFD25E8CD0364141ULL,  /* bits   0-63  */
+    0xBAAEDCE6AF48A03BULL,  /* bits  64-127 */
+    0xFFFFFFFFFFFFFFFEULL,  /* bits 128-191 */
+    0xFFFFFFFFFFFFFFFFULL   /* bits 192-255 */
+}};
+
+/* -----------------------------------------------------------------------
  * Deterministic PRNG — xorshift64 (Marsaglia, 2003)
  *
  * Using a deterministic PRNG avoids potential timing variation from
@@ -575,6 +587,182 @@ static int test_point_ops(void)
 }
 
 /* -----------------------------------------------------------------------
+ * Scalar arithmetic timing tests (dudect)
+ *
+ * Post-#21, scalar_reduce_limbs is fully branchless — no operand-dependent
+ * control flow.  These tests confirm scalar_mul_internal, scalar_reduce,
+ * and scalar_inv_internal execute in constant time across operand bands
+ * that previously took different paths (e.g. topcarry == 1 vs 0 in the
+ * residual fold).
+ *
+ * scalar_inv runs ~256 scalar_mul_internal calls in its Fermat ladder — it
+ * is the realistic ECDSA k^-1 path an adversary would target.  The
+ * conditional in the ladder iterates over bits of the PUBLIC N-2, which
+ * is safe; the per-iteration scalar_mul_internal operates on secret data.
+ * ----------------------------------------------------------------------- */
+
+#define SCALAR_OP_MEASUREMENTS  1000000
+#define SCALAR_INV_MEASUREMENTS 1000
+
+/*
+ * test_scalar_mul_arith — timing test for scalar_mul_internal.
+ *
+ * Symmetric setup — both classes run the same xorshift sequence; only the
+ * top-limb mask differs.
+ *   Class A: operands < 2^192 (top limb masked to 0).
+ *   Class B: operands across the full 2^256 range.
+ *
+ * Top-limb magnitude controls the product's high half, which exercises the
+ * residual-fold and topcarry branches.  Post-#21 those are branchless, so
+ * timing should be indistinguishable up to microarchitectural noise
+ * (cf. jp_add_internal in docs/security.md).
+ */
+static int test_scalar_mul_arith(void)
+{
+    dudect_ctx_t ctx;
+    dudect_init(&ctx);
+    int i;
+
+    for (i = 0; i < SCALAR_OP_MEASUREMENTS; i++) {
+        uint256_t a, b, r;
+        int class_id = i & 1;
+        uint64_t t0, t1;
+
+        /* top_mask: class 0 -> 0 (top limb zeroed); class 1 -> all 1s. */
+        uint64_t top_mask = -(uint64_t)class_id;
+
+        a.d[0] = xorshift64();
+        a.d[1] = xorshift64();
+        a.d[2] = xorshift64();
+        a.d[3] = xorshift64() & top_mask;
+        b.d[0] = xorshift64();
+        b.d[1] = xorshift64();
+        b.d[2] = xorshift64();
+        b.d[3] = xorshift64() & top_mask;
+
+        t0 = timing_now_ns();
+        scalar_mul_internal(&r, &a, &b);
+        t1 = timing_now_ns();
+
+        dudect_add(&ctx, class_id, (double)(t1 - t0));
+    }
+
+    dudect_report(&ctx, "scalar_mul_internal");
+    return dudect_passed(&ctx);
+}
+
+/*
+ * test_scalar_reduce_arith — timing test for scalar_reduce (hi:lo -> mod N).
+ *
+ * Symmetric setup — both classes assemble hi from CURVE_N via the same
+ * mask.  Class A masks hi entirely to 0; class B keeps hi = N+1 (exercises
+ * the topcarry path that was the H-1 site).
+ */
+static int test_scalar_reduce_arith(void)
+{
+    dudect_ctx_t ctx;
+    dudect_init(&ctx);
+    int i;
+
+    for (i = 0; i < SCALAR_OP_MEASUREMENTS; i++) {
+        uint256_t hi = CURVE_N;
+        uint256_t lo, r;
+        int class_id = i & 1;
+        uint64_t t0, t1;
+
+        /* hi_mask: class 0 -> 0 (hi becomes 0); class 1 -> all 1s (hi = N). */
+        uint64_t hi_mask = -(uint64_t)class_id;
+        hi.d[0] = (hi.d[0] & hi_mask) + (uint64_t)class_id;  /* +1 in class 1 -> N+1 */
+        hi.d[1] &= hi_mask;
+        hi.d[2] &= hi_mask;
+        hi.d[3] &= hi_mask;
+
+        lo.d[0] = xorshift64();
+        lo.d[1] = xorshift64();
+        lo.d[2] = xorshift64();
+        lo.d[3] = xorshift64();
+
+        t0 = timing_now_ns();
+        scalar_reduce(&r, &hi, &lo);
+        t1 = timing_now_ns();
+
+        dudect_add(&ctx, class_id, (double)(t1 - t0));
+    }
+
+    dudect_report(&ctx, "scalar_reduce");
+    return dudect_passed(&ctx);
+}
+
+/*
+ * test_scalar_inv_arith — timing test for scalar_inv_internal.
+ *
+ *   Class A: fixed input a = 2 (minimal Hamming weight).
+ *   Class B: random input a in [1, N-1].
+ *
+ * scalar_inv_internal runs ~256 scalar_mul_internal calls on the secret
+ * base; if scalar_mul_internal is CT, the full Fermat ladder should also
+ * be timing-indistinguishable across the two classes.
+ *
+ * Uses 1000 measurements — scalar_inv_internal is ~256x slower than a
+ * single scalar_mul_internal.
+ */
+static int test_scalar_inv_arith(void)
+{
+    dudect_ctx_t ctx;
+    dudect_init(&ctx);
+    int i;
+
+    uint256_t fixed_a = {{ 2ULL, 0ULL, 0ULL, 0ULL }};
+
+    for (i = 0; i < SCALAR_INV_MEASUREMENTS; i++) {
+        uint256_t a, r;
+        int class_id = i & 1;
+        uint64_t t0, t1;
+
+        if (class_id == 0) {
+            a = fixed_a;
+        } else {
+            random_scalar_mod_n(&a);
+            if (uint256_is_zero(&a)) {
+                a.d[0] = 1;
+            }
+        }
+
+        t0 = timing_now_ns();
+        scalar_inv_internal(&r, &a);
+        t1 = timing_now_ns();
+
+        dudect_add(&ctx, class_id, (double)(t1 - t0));
+    }
+
+    dudect_report(&ctx, "scalar_inv_internal");
+    return dudect_passed(&ctx);
+}
+
+/*
+ * test_scalar_ops — run all three scalar arithmetic timing tests.
+ */
+static int test_scalar_ops(void)
+{
+    int failures = 0;
+
+    printf("\n[8] Scalar arithmetic timing tests (dudect)\n\n");
+
+    printf("  scalar_mul_internal: %d measurements\n", SCALAR_OP_MEASUREMENTS);
+    if (!test_scalar_mul_arith()) failures++;
+
+    printf("\n  scalar_reduce: %d measurements\n", SCALAR_OP_MEASUREMENTS);
+    if (!test_scalar_reduce_arith()) failures++;
+
+    printf("\n  scalar_inv_internal: %d measurements (slow — ~256 mul each)\n",
+           SCALAR_INV_MEASUREMENTS);
+    if (!test_scalar_inv_arith()) failures++;
+
+    printf("\n  Scalar timing: %d/3 passed\n\n", 3 - failures);
+    return failures > 0 ? 1 : 0;
+}
+
+/* -----------------------------------------------------------------------
  * Helpers
  * ----------------------------------------------------------------------- */
 
@@ -700,6 +888,12 @@ int main(void)
     /* Run scalar multiplication and point operation timing tests */
     if (test_point_ops() != 0) {
         fprintf(stderr, "FAIL: point operation timing tests detected leakage\n");
+        exit_code = 1;
+    }
+
+    /* Run scalar arithmetic timing tests (#21) */
+    if (test_scalar_ops() != 0) {
+        fprintf(stderr, "FAIL: scalar arithmetic timing tests detected leakage\n");
         exit_code = 1;
     }
 

--- a/timing/timing_harness.c
+++ b/timing/timing_harness.c
@@ -696,12 +696,18 @@ static int test_scalar_reduce_arith(void)
 /*
  * test_scalar_inv_arith — timing test for scalar_inv_internal.
  *
+ * Symmetric setup — both classes generate a random scalar then mask-select
+ * between the fixed value (class 0) and the random one (class 1).  This
+ * mirrors the scalar_mul / scalar_reduce pattern in this file and the
+ * test_fred pattern in the field section: identical per-iteration setup
+ * cost in both classes, so the t-test reflects only the timed op.
+ *
  *   Class A: fixed input a = 2 (minimal Hamming weight).
  *   Class B: random input a in [1, N-1].
  *
  * scalar_inv_internal runs ~256 scalar_mul_internal calls on the secret
- * base; if scalar_mul_internal is CT, the full Fermat ladder should also
- * be timing-indistinguishable across the two classes.
+ * base; if scalar_mul_internal is CT, the full Fermat ladder should be
+ * timing-indistinguishable across the two classes.
  *
  * Uses 1000 measurements — scalar_inv_internal is ~256x slower than a
  * single scalar_mul_internal.
@@ -715,18 +721,24 @@ static int test_scalar_inv_arith(void)
     uint256_t fixed_a = {{ 2ULL, 0ULL, 0ULL, 0ULL }};
 
     for (i = 0; i < SCALAR_INV_MEASUREMENTS; i++) {
-        uint256_t a, r;
+        uint256_t a, r, random_a;
         int class_id = i & 1;
         uint64_t t0, t1;
 
-        if (class_id == 0) {
-            a = fixed_a;
-        } else {
-            random_scalar_mod_n(&a);
-            if (uint256_is_zero(&a)) {
-                a.d[0] = 1;
-            }
+        /* Symmetric setup: both classes generate a random scalar (the
+         * "use fixed" decision later is a branchless mask-select).  The
+         * is_zero guard fires with probability ~2^-256, equally in both
+         * classes, so it does not bias the t-test. */
+        random_scalar_mod_n(&random_a);
+        if (uint256_is_zero(&random_a)) {
+            random_a.d[0] = 1;
         }
+
+        uint64_t mask = -(uint64_t)class_id;  /* class 0 -> 0, class 1 -> all 1s */
+        a.d[0] = (random_a.d[0] & mask) | (fixed_a.d[0] & ~mask);
+        a.d[1] = (random_a.d[1] & mask) | (fixed_a.d[1] & ~mask);
+        a.d[2] = (random_a.d[2] & mask) | (fixed_a.d[2] & ~mask);
+        a.d[3] = (random_a.d[3] & mask) | (fixed_a.d[3] & ~mask);
 
         t0 = timing_now_ns();
         scalar_inv_internal(&r, &a);


### PR DESCRIPTION
## Summary

Closes the v1-blocker triple finding from the pre-v1.0 security review (#20, `docs/security-review-v1.md` §3):

- **H-1 (high)** — `scalar_reduce_limbs` dropped the carry out of bit 255 in the residual fold, so `scalar_mul(2²⁵⁶−1, N+2)` returned a value *wrong by exactly c_N and still in [0, N)*. Surfaced through `scalar_mul_internal` and `rb_scalar_mul`. Random testing cannot reach H-1's band (density ≈ 2⁻³⁸⁴).
- **I-2 (info, same root cause)** — same defect viewed at the `scalar_reduce` primitive (`hi = N+1` row).
- **I-11 (low, same function)** — secret-dependent branches `if (h == 0) continue;` and `if (carry3)` in the residual fold.

The fix replaces the residual-fold + final-reduction tail of `scalar_reduce_limbs` so the dropped top carry is now *captured* and a branchless mask select picks `r − N` whenever `topcarry | (1 ^ borrow)` is set. Plus belt-and-braces operand pre-reduction at the Ruby boundary, plus regression tests, plus the timing-harness extension the HLR asked for, plus the gate-script cleanup the I-11 closure makes possible.

Six conventional commits, each with `Refs #21`. See [the synthesised breakdown comment](https://github.com/sgbett/secp256k1-native/issues/21#issuecomment-4831856445) on #21 for the per-task scope and conflict resolutions.

## Test plan

- [x] **374 / 374 RSpec pass** (was 368, +6 new regression vectors: H-1, worst-case product, non-canonical squaring, boundary mod, Fermat consistency across adversarial bases).
- [x] **Differential gate (`security/dfuzz_ref.py`)** — `known-defect vectors reproducing=0/4` for the `smul` and `sreduce` cases; the 2/4 remaining are `sadd` (M-1, #22 scope).
- [x] **ASan / UBSan sweep** — `PASS` (no sanitizer diagnostics, 20 000 iters in Docker).
- [x] **ctgrind secret-poisoning** (Docker on macOS ARM64) — `PASS: 0 errors`. **I-11 closed.**
- [x] **New dudect scalar tests** (Apple M4 dev hardware, not bare-metal):
  - `scalar_mul_internal`: |t| = 1.0  PASS  (1 000 000 measurements)
  - `scalar_reduce`: |t| = 0.7  PASS  (1 000 000 measurements)
  - `scalar_inv_internal`: |t| = 0.2  PASS  (1 000 measurements, ~256 mul each)
- [ ] **Bare-metal dudect re-run** (#25) — not blocking; local dev hardware corroborates but is not the binding measurement.

## Notes

- The defence-in-depth pre-reduction in `rb_scalar_mul` (commit `c46b5b2`) means the H-1 RSpec vector exercises end-to-end correctness, not the primitive directly. The primitive remains covered by `security/dfuzz_harness.c`'s `smul` op (verified above). Test commentary explains this.
- `EXPECT_I11` removed from `security/run-checks.sh` (commit `b808f32`) since the I-11 branches no longer exist.
- `docs/security.md` gains a "Scalar arithmetic" subsection under CT discipline plus a new dudect table.
- White-hat security gate: **approve-with-followup**, no blockers. Two low-severity tightenings (overclaimed `t[4] ≤ 1` invariant, H-1 test commentary) addressed in commit `fcb88c1`.

## Specialist co-production

Five lenses ran in parallel before implementation; full synthesis in the [HLR comment](https://github.com/sgbett/secp256k1-native/issues/21#issuecomment-4831856445). Notable conflicts resolved:
- **Pragmatic Enforcer vs Implementation Strategist** on `rb_scalar_mul` defence-in-depth: kept (Strategist defended as the public-boundary contract enforcement).
- **Maintainability** on `EXPECT_I11` flip → remove: adopted (don't leave stale conditional logic).
- **Pragmatic** on deferring the dudect extension: kept in scope (HLR §AC binds it).

## Follow-up to file post-merge

- **`bench:scalar` rake task** — Performance Specialist recommendation; not in HLR scope.

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)