### PR TITLE
fix: enforce Ruby↔C boundary contracts (M-1 / L-3 / I-3 / L-4 / L-1 / L-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so
 *.o
 *.a
+*.dSYM/
 Gemfile.lock
 tmp/
 pkg/

--- a/docs/security.md
+++ b/docs/security.md
@@ -69,6 +69,13 @@ After #22, the Ruby-facing wrappers enforce — not merely document — the Inte
 
 The C `_internal` functions retain the documented `a, b < P` / `< N` preconditions and are called directly from `jacobian.c` (which only feeds canonical intermediates) and from the wrappers post-reduction.
 
+#### Pure-Ruby fallback divergences
+
+Two intentional divergences exist between the pure-Ruby module functions (used when the C extension is not loaded) and the native wrappers:
+
+- **Low-level field/scalar methods do not type-check.** `Secp256k1.fmul(1.5, 2)` and similar will compute on the Float value rather than raising `TypeError`. The user-facing `Point#mul` / `#mul_vt` reject non-Integer scalars at the Ruby boundary on both backends; the low-level pure-Ruby methods are documented as expecting `Integer` and do not enforce it. Users who need strict typing on the low-level surface should ensure the C extension is loaded.
+- **`fsub` / `fneg` accept negative inputs in pure-Ruby**, returning the canonical non-negative residue (Ruby `%` semantics). The C wrappers reject negatives via `rb_to_uint256`. Backend parity holds for all non-negative inputs; the dfuzz harness only feeds non-negative inputs so the differential never observes this case.
+
 `scalar_inv_internal` iterates over bits of the public constant N-2 via Fermat's little theorem. The branch on each bit is over public data; the per-iteration `scalar_mul_internal` operates on the secret base and is branchless.
 
 ### Montgomery ladder

--- a/docs/security.md
+++ b/docs/security.md
@@ -60,7 +60,7 @@ The scalar operations `scalar_mul_internal`, `scalar_reduce`, and `scalar_add_in
 
 After #22, the Ruby-facing wrappers enforce — not merely document — the Integer-in-`[0, P)` / `[0, N)` contract for every operation:
 
-- All 16 native wrappers reject non-Integer inputs at `rb_to_uint256` with `TypeError` (L-1). One guard covers the whole module.
+- All 16 native wrappers reject non-Integer inputs with `TypeError` (L-1). The 256-bit wrappers share one guard at `rb_to_uint256`; `rb_fred` packs 8 limbs directly (for 512-bit intermediates) and carries its own `RB_INTEGER_TYPE_P` guard.
 - `rb_fadd` / `rb_fsub` / `rb_fneg` pre-reduce operands via `fred_internal` so the `_internal` functions' `a, b < P` precondition is always met (L-3, I-3).
 - `rb_scalar_add` pre-reduces both operands mod N (M-1).
 - `rb_scalar_mod` accepts any-width Integer (positive or negative) via Ruby `%` (L-4).

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,6 +56,19 @@ Inversion (`finv`) and square root (`fsqrt`) iterate over public constants (P-2 
 
 The scalar operations `scalar_mul_internal`, `scalar_reduce`, and `scalar_add_internal` use branchless conditional selection — bitwise masks from carry/borrow flags and a captured topcarry — with no operand-dependent control flow. After the #21 fix, `scalar_reduce_limbs` is fully branchless: the previous `if (h == 0) continue` and `if (carry3)` guards in the residual fold were removed (the second-fold loop body is a faithful no-op when `h == 0`; the residual fold is now unconditional with topcarry capture, replacing the dropped-carry tail that caused H-1).
 
+### Ruby↔C boundary contracts (#22)
+
+After #22, the Ruby-facing wrappers enforce — not merely document — the Integer-in-`[0, P)` / `[0, N)` contract for every operation:
+
+- All 16 native wrappers reject non-Integer inputs at `rb_to_uint256` with `TypeError` (L-1). One guard covers the whole module.
+- `rb_fadd` / `rb_fsub` / `rb_fneg` pre-reduce operands via `fred_internal` so the `_internal` functions' `a, b < P` precondition is always met (L-3, I-3).
+- `rb_scalar_add` pre-reduces both operands mod N (M-1).
+- `rb_scalar_mod` accepts any-width Integer (positive or negative) via Ruby `%` (L-4).
+- `Point#mul` / `#mul_vt` reject non-Integer scalars with `ArgumentError` at the Ruby boundary (L-2). `Point#initialize` rejects y outside `[0, P)`.
+- Pure-Ruby `fsub` / `fneg` canonicalise operands so the dfuzz differential's Ruby oracle agrees with the C wrapper on ≥ P inputs.
+
+The C `_internal` functions retain the documented `a, b < P` / `< N` preconditions and are called directly from `jacobian.c` (which only feeds canonical intermediates) and from the wrappers post-reduction.
+
 `scalar_inv_internal` iterates over bits of the public constant N-2 via Fermat's little theorem. The branch on each bit is over public data; the per-iteration `scalar_mul_internal` operates on the secret base and is branchless.
 
 ### Montgomery ladder

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -24,6 +24,13 @@
  * so that only one copy of each function exists in the linked extension.
  * ----------------------------------------------------------------------- */
 
+/*
+ * Marshal a Ruby Integer into a uint256_t.
+ *
+ * @raise [TypeError] if rb_int is not an Integer (L-1: rejects Float,
+ *   Rational, BigDecimal, nil, anything responding to #to_int).
+ * @raise [ArgumentError] if rb_int is negative or exceeds 256 bits.
+ */
 uint256_t rb_to_uint256(VALUE rb_int)
 {
     /* L-1: reject non-Integer before reaching rb_integer_pack, which itself
@@ -316,6 +323,10 @@ void fsqr_internal(uint256_t *r, const uint256_t *a)
  * fadd_internal — modular addition.
  *
  * Computes a + b, then branchlessly subtracts P if the result >= P.
+ *
+ * Precondition: a, b < P (canonical).  Pre-reduction is the wrapper's
+ * responsibility — see rb_fadd.  The Jacobian path (jacobian.c) only feeds
+ * canonical intermediates produced by other internals.
  */
 void fadd_internal(uint256_t *r, const uint256_t *a, const uint256_t *b)
 {
@@ -343,6 +354,8 @@ void fadd_internal(uint256_t *r, const uint256_t *a, const uint256_t *b)
  * fsub_internal — modular subtraction.
  *
  * Computes a - b; if the result underflows, adds P back — branchlessly.
+ *
+ * Precondition: a, b < P (canonical) — see fadd_internal.
  */
 void fsub_internal(uint256_t *r, const uint256_t *a, const uint256_t *b)
 {
@@ -366,6 +379,8 @@ void fsub_internal(uint256_t *r, const uint256_t *a, const uint256_t *b)
  * fneg_internal — modular negation.
  *
  * Returns P - a for non-zero a, and 0 for a == 0 — branchlessly.
+ *
+ * Precondition: a < P (canonical) — see fadd_internal.
  */
 void fneg_internal(uint256_t *r, const uint256_t *a)
 {

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -479,6 +479,14 @@ int fsqrt_internal(uint256_t *r, const uint256_t *a)
 static VALUE rb_fred(VALUE self, VALUE x)
 {
     (void)self;
+    /* L-1: reject non-Integer before rb_integer_pack, which would silently
+     * coerce Float / Rational / objects responding to #to_int.  rb_fred packs
+     * 8 limbs (vs 4 in rb_to_uint256), so it does not flow through that
+     * helper — guard locally to honour the same boundary contract. */
+    if (!RB_INTEGER_TYPE_P(x)) {
+        rb_raise(rb_eTypeError, "expected Integer");
+    }
+
     /* fred is used for reducing wide intermediates.  Pack into 8 limbs. */
     uint64_t limbs[8];
     memset(limbs, 0, sizeof(limbs));

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -519,8 +519,17 @@ static VALUE rb_fadd(VALUE self, VALUE a, VALUE b)
     (void)self;
     uint256_t ua = rb_to_uint256(a);
     uint256_t ub = rb_to_uint256(b);
+
+    /* L-3: pre-reduce operands so fadd_internal's `a, b < P` precondition is
+     * always satisfied (mirrors rb_finv / rb_fsqrt).  fred handles 512-bit
+     * inputs; here we use hi=0 so it's a single fast pass on each operand. */
+    uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
+    uint256_t ua_reduced, ub_reduced;
+    fred_internal(&ua_reduced, &zero_limbs, &ua);
+    fred_internal(&ub_reduced, &zero_limbs, &ub);
+
     uint256_t r;
-    fadd_internal(&r, &ua, &ub);
+    fadd_internal(&r, &ua_reduced, &ub_reduced);
     return uint256_to_rb(&r);
 }
 
@@ -535,8 +544,15 @@ static VALUE rb_fsub(VALUE self, VALUE a, VALUE b)
     (void)self;
     uint256_t ua = rb_to_uint256(a);
     uint256_t ub = rb_to_uint256(b);
+
+    /* L-3: pre-reduce operands (see rb_fadd). */
+    uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
+    uint256_t ua_reduced, ub_reduced;
+    fred_internal(&ua_reduced, &zero_limbs, &ua);
+    fred_internal(&ub_reduced, &zero_limbs, &ub);
+
     uint256_t r;
-    fsub_internal(&r, &ua, &ub);
+    fsub_internal(&r, &ua_reduced, &ub_reduced);
     return uint256_to_rb(&r);
 }
 
@@ -550,8 +566,15 @@ static VALUE rb_fneg(VALUE self, VALUE a)
 {
     (void)self;
     uint256_t ua = rb_to_uint256(a);
+
+    /* L-3 / I-3: pre-reduce the operand so fneg_internal's `a < P`
+     * precondition is always satisfied (mirrors rb_finv / rb_fsqrt). */
+    uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
+    uint256_t ua_reduced;
+    fred_internal(&ua_reduced, &zero_limbs, &ua);
+
     uint256_t r;
-    fneg_internal(&r, &ua);
+    fneg_internal(&r, &ua_reduced);
     return uint256_to_rb(&r);
 }
 

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -26,6 +26,15 @@
 
 uint256_t rb_to_uint256(VALUE rb_int)
 {
+    /* L-1: reject non-Integer before reaching rb_integer_pack, which itself
+     * calls rb_to_int and would silently coerce Float / Rational / objects
+     * responding to #to_int.  This check is the single load-bearing guard
+     * for ALL 16 wrappers' Integer contract — it must come FIRST, before
+     * rb_integer_pack mutates the input. */
+    if (!RB_INTEGER_TYPE_P(rb_int)) {
+        rb_raise(rb_eTypeError, "expected Integer");
+    }
+
     uint256_t n;
     memset(&n, 0, sizeof(n));
     int result = rb_integer_pack(rb_int, n.d, 4, sizeof(uint64_t), 0, U256_PACK_FLAGS);

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -356,6 +356,14 @@ static VALUE rb_scalar_mod(VALUE self, VALUE a)
 {
     (void)self;
 
+    /* L-1: reject non-Integer BEFORE Ruby `%` is dispatched on the receiver.
+     * Without this, a String would raise NoMethodError (no `%` of Integer),
+     * and any object whose `%` happens to return an Integer would silently
+     * succeed — both bypass the wrapper's documented TypeError contract. */
+    if (!RB_INTEGER_TYPE_P(a)) {
+        rb_raise(rb_eTypeError, "expected Integer");
+    }
+
     /* L-4: pre-reduce via Ruby `%` unconditionally.  This is intentionally
      * different from the other scalar wrappers (which use the C-level
      * scalar_reduce): Ruby `%` handles both negative inputs (returns the

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -293,6 +293,9 @@ static void scalar_sqr_internal(uint256_t *r, const uint256_t *a)
  * scalar_add_internal — modular addition mod N.
  *
  * Computes a + b, then branchlessly subtracts N if the result >= N.
+ *
+ * Precondition: a, b < N (canonical).  Pre-reduction is the wrapper's
+ * responsibility — see rb_scalar_add.
  */
 void scalar_add_internal(uint256_t *r, const uint256_t *a, const uint256_t *b)
 {

--- a/ext/secp256k1_native/scalar.c
+++ b/ext/secp256k1_native/scalar.c
@@ -346,25 +346,21 @@ void scalar_inv_internal(uint256_t *r, const uint256_t *a)
  * call-seq:
  *   Secp256k1Native.scalar_mod(a) -> Integer
  *
- * Reduce +a+ modulo the curve order N.  Handles negative Ruby Integers:
- * if +a+ is negative, the result is +a mod N+ in the range [0, N).
+ * Reduce +a+ modulo the curve order N.  Accepts any Ruby Integer — negative,
+ * positive, and arbitrary width (including values >= 2^256).
  */
 static VALUE rb_scalar_mod(VALUE self, VALUE a)
 {
     (void)self;
 
-    /* Handle negative values by delegating to Ruby's own % operator which
-     * always returns a non-negative result for a positive modulus. */
+    /* L-4: pre-reduce via Ruby `%` unconditionally.  This is intentionally
+     * different from the other scalar wrappers (which use the C-level
+     * scalar_reduce): Ruby `%` handles both negative inputs (returns the
+     * non-negative residue) and arbitrary width (rb_to_uint256 would raise
+     * "exceeds 256 bits" on values >= 2^256 otherwise), so it is the right
+     * canonicalisation primitive at this boundary. */
     VALUE n_rb  = uint256_to_rb(&CURVE_N);
-    int negative = RTEST(rb_funcall(a, rb_intern("<"), 1, INT2FIX(0)));
-
-    VALUE a_norm;
-    if (negative) {
-        /* Ruby % is always non-negative when the modulus is positive */
-        a_norm = rb_funcall(a, rb_intern("%"), 1, n_rb);
-    } else {
-        a_norm = a;
-    }
+    VALUE a_norm = rb_funcall(a, rb_intern("%"), 1, n_rb);
 
     uint256_t ua = rb_to_uint256(a_norm);
     uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
@@ -437,8 +433,18 @@ static VALUE rb_scalar_add(VALUE self, VALUE a, VALUE b)
     (void)self;
     uint256_t ua = rb_to_uint256(a);
     uint256_t ub = rb_to_uint256(b);
+
+    /* M-1 correctness fix: scalar_add_internal subtracts N at most once and is
+     * therefore correct only when both operands are already < N.  Pre-reduce
+     * both operands mod N so the wrapper's documented `(a + b) mod N` contract
+     * holds for any 256-bit input (mirrors rb_scalar_inv / rb_scalar_mul). */
+    uint256_t zero_limbs = {{ 0ULL, 0ULL, 0ULL, 0ULL }};
+    uint256_t ua_reduced, ub_reduced;
+    scalar_reduce(&ua_reduced, &zero_limbs, &ua);
+    scalar_reduce(&ub_reduced, &zero_limbs, &ub);
+
     uint256_t r;
-    scalar_add_internal(&r, &ua, &ub);
+    scalar_add_internal(&r, &ua_reduced, &ub_reduced);
     return uint256_to_rb(&r);
 }
 

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -140,8 +140,14 @@ module Secp256k1
   # Modular subtraction in the field.
   #
   # Canonicalises both operands so the result matches the C wrapper for any
-  # 256-bit input — load-bearing for the dfuzz differential, where pure-Ruby
-  # serves as the oracle.
+  # *non-negative* 256-bit input — load-bearing for the dfuzz differential,
+  # where pure-Ruby serves as the oracle. The dfuzz harness only feeds
+  # non-negative inputs (xorshift output, plus structured P-band vectors),
+  # so the differential never observes the negative case.
+  #
+  # Note: pure-Ruby accepts negative inputs (Ruby `%` canonicalises them);
+  # the C wrapper rejects negatives via `rb_to_uint256`. Backend parity
+  # holds for all >= 0 inputs; intentional divergence on negatives.
   def fsub(a, b)
     a %= P
     b %= P
@@ -151,7 +157,7 @@ module Secp256k1
   # Modular negation in the field.
   #
   # Canonicalises the operand so the result matches the C wrapper for any
-  # 256-bit input — see {#fsub}.
+  # non-negative 256-bit input — see {#fsub} for the negative-input note.
   def fneg(a)
     a %= P
     a.zero? ? 0 : P - a
@@ -447,14 +453,22 @@ module Secp256k1
 
     # @param x [Integer, nil] x-coordinate (nil for infinity)
     # @param y [Integer, nil] y-coordinate (nil for infinity)
-    # @raise [ArgumentError] if y is not nil and not in [0, P)
+    # @raise [ArgumentError] if x and y are not both nil and not both
+    #   Integers in [0, P)
     def initialize(x, y)
-      # I-3 mitigation: reject out-of-range y at the constructor so
-      # downstream paths (e.g. `Point#negate`) can rely on the y-coordinate
-      # being canonical. x is left permissive — `on_curve?` validates the
-      # full pair when needed.
-      unless y.nil? || (y.is_a?(Integer) && y >= 0 && y < P)
-        raise ArgumentError, 'y must be nil or an Integer in [0, P)'
+      # I-3 mitigation, hardened: only two valid shapes are accepted —
+      # the point at infinity (nil, nil), or a finite point with both
+      # coordinates canonical in [0, P). Catches Point.new(1, P-of-range),
+      # Point.new(-1, 5), Point.new(nil, 5), and similar half-states at
+      # construction so no downstream path (negate, to_octet_string,
+      # on_curve?) has to second-guess the invariant.
+      if x.nil? && y.nil?
+        # point at infinity — both coordinates absent
+      elsif x.is_a?(Integer) && y.is_a?(Integer) && x >= 0 && x < P && y >= 0 && y < P
+        # finite point with canonical coordinates
+      else
+        raise ArgumentError,
+              'Point requires (nil, nil) for infinity or two Integers in [0, P)'
       end
 
       @x = x

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -138,12 +138,22 @@ module Secp256k1
   end
 
   # Modular subtraction in the field.
+  #
+  # Canonicalises both operands so the result matches the C wrapper for any
+  # 256-bit input — load-bearing for the dfuzz differential, where pure-Ruby
+  # serves as the oracle.
   def fsub(a, b)
+    a %= P
+    b %= P
     a >= b ? a - b : P - (b - a)
   end
 
   # Modular negation in the field.
+  #
+  # Canonicalises the operand so the result matches the C wrapper for any
+  # 256-bit input — see {#fsub}.
   def fneg(a)
+    a %= P
     a.zero? ? 0 : P - a
   end
 
@@ -437,7 +447,16 @@ module Secp256k1
 
     # @param x [Integer, nil] x-coordinate (nil for infinity)
     # @param y [Integer, nil] y-coordinate (nil for infinity)
+    # @raise [ArgumentError] if y is not nil and not in [0, P)
     def initialize(x, y)
+      # I-3 mitigation: reject out-of-range y at the constructor so
+      # downstream paths (e.g. `Point#negate`) can rely on the y-coordinate
+      # being canonical. x is left permissive — `on_curve?` validates the
+      # full pair when needed.
+      unless y.nil? || (y.is_a?(Integer) && y >= 0 && y < P)
+        raise ArgumentError, 'y must be nil or an Integer in [0, P)'
+      end
+
       @x = x
       @y = y
     end

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -577,10 +577,8 @@ module Secp256k1
               'Set SECP256K1_ALLOW_PURE_RUBY_CT=1 or call Secp256k1.allow_pure_ruby_ct! to override.'
       end
 
-      return self.class.infinity if scalar.zero? || infinity?
-
-      scalar %= N
-      return self.class.infinity if scalar.zero?
+      scalar = normalise_scalar(scalar)
+      return self.class.infinity if scalar.nil?
 
       jp = Secp256k1.scalar_multiply_ct(scalar, @x, @y)
       affine = Secp256k1.jp_to_affine(jp)
@@ -601,10 +599,8 @@ module Secp256k1
     # @param scalar [Integer] the public scalar multiplier
     # @return [Point] the resulting point
     def mul_vt(scalar)
-      return self.class.infinity if scalar.zero? || infinity?
-
-      scalar %= N
-      return self.class.infinity if scalar.zero?
+      scalar = normalise_scalar(scalar)
+      return self.class.infinity if scalar.nil?
 
       jp = Secp256k1.scalar_multiply_wnaf(scalar, @x, @y)
       affine = Secp256k1.jp_to_affine(jp)
@@ -612,6 +608,28 @@ module Secp256k1
 
       self.class.new(affine[0], affine[1])
     end
+
+    private
+
+    # Validate and canonicalise a scalar for multiplication (L-2).
+    #
+    # @param scalar [Integer] the scalar multiplier
+    # @return [Integer, nil] the scalar reduced mod N, or nil if the
+    #   product would be infinity (scalar is zero mod N, or self is the
+    #   point at infinity)
+    # @raise [ArgumentError] if scalar is not an Integer
+    def normalise_scalar(scalar)
+      raise ArgumentError, 'scalar must be an Integer' unless scalar.is_a?(Integer)
+
+      return nil if infinity?
+
+      scalar %= N
+      return nil if scalar.zero?
+
+      scalar
+    end
+
+    public
 
     # Point addition: self + other.
     #

--- a/security/dfuzz_harness.c
+++ b/security/dfuzz_harness.c
@@ -50,14 +50,27 @@ int main(void) {
             hex_to_u256(h[0], &a);
             uint256_t r; fsqr_internal(&r, &a); print_u256(&r); printf("\n");
         } else if (strcmp(op, "fadd") == 0) {
+            /* Mirror rb_fadd: pre-reduce operands via fred_internal so the
+             * differential tests post-wrapper behaviour (L-3 fix lives in the
+             * wrapper; fadd_internal still assumes a, b < P). */
             hex_to_u256(h[0], &a); hex_to_u256(h[1], &b);
-            uint256_t r; fadd_internal(&r, &a, &b); print_u256(&r); printf("\n");
+            uint256_t zero = {{0,0,0,0}}, a_red, b_red;
+            fred_internal(&a_red, &zero, &a);
+            fred_internal(&b_red, &zero, &b);
+            uint256_t r; fadd_internal(&r, &a_red, &b_red); print_u256(&r); printf("\n");
         } else if (strcmp(op, "fsub") == 0) {
+            /* Mirror rb_fsub: pre-reduce operands (L-3). */
             hex_to_u256(h[0], &a); hex_to_u256(h[1], &b);
-            uint256_t r; fsub_internal(&r, &a, &b); print_u256(&r); printf("\n");
+            uint256_t zero = {{0,0,0,0}}, a_red, b_red;
+            fred_internal(&a_red, &zero, &a);
+            fred_internal(&b_red, &zero, &b);
+            uint256_t r; fsub_internal(&r, &a_red, &b_red); print_u256(&r); printf("\n");
         } else if (strcmp(op, "fneg") == 0) {
+            /* Mirror rb_fneg: pre-reduce operand (I-3). */
             hex_to_u256(h[0], &a);
-            uint256_t r; fneg_internal(&r, &a); print_u256(&r); printf("\n");
+            uint256_t zero = {{0,0,0,0}}, a_red;
+            fred_internal(&a_red, &zero, &a);
+            uint256_t r; fneg_internal(&r, &a_red); print_u256(&r); printf("\n");
         } else if (strcmp(op, "finv") == 0) {
             hex_to_u256(h[0], &a);
             uint256_t r; finv_internal(&r, &a); print_u256(&r); printf("\n");
@@ -72,8 +85,14 @@ int main(void) {
             hex_to_u256(h[0], &a); hex_to_u256(h[1], &b);
             uint256_t r; scalar_mul_internal(&r, &a, &b); print_u256(&r); printf("\n");
         } else if (strcmp(op, "sadd") == 0) {
+            /* Mirror rb_scalar_add: pre-reduce operands via scalar_reduce so
+             * the differential tests post-wrapper behaviour (M-1 fix lives in
+             * the wrapper; scalar_add_internal still assumes a, b < N). */
             hex_to_u256(h[0], &a); hex_to_u256(h[1], &b);
-            uint256_t r; scalar_add_internal(&r, &a, &b); print_u256(&r); printf("\n");
+            uint256_t zero = {{0,0,0,0}}, a_red, b_red;
+            scalar_reduce(&a_red, &zero, &a);
+            scalar_reduce(&b_red, &zero, &b);
+            uint256_t r; scalar_add_internal(&r, &a_red, &b_red); print_u256(&r); printf("\n");
         } else if (strcmp(op, "sinv") == 0) {
             hex_to_u256(h[0], &a);
             uint256_t r; scalar_inv_internal(&r, &a); print_u256(&r); printf("\n");

--- a/security/dfuzz_ref.py
+++ b/security/dfuzz_ref.py
@@ -198,22 +198,30 @@ if __name__ == "__main__":
     print(f"in-contract random pass: {args.iters} iters/op-class, {len(fails)} mismatches")
     incontract = len(fails)
 
-    # ---- structured regression vectors that reproduce the documented findings ----
+    # ---- structured regression vectors for documented findings ----
     # These are the load-bearing cases random testing provably cannot reach
-    # (H-1's failing band has density ~2^-384). Each is EXPECTED to diverge on the
-    # reviewed v1.0 tree and must turn clean once the H-1/M-1 fixes land.
-    print("\nstructured regression vectors (expected to diverge until fixed):")
+    # (H-1's failing band has density ~2^-384). Each was EXPECTED to diverge
+    # on the reviewed v1.0 tree; post-#21 (scalar reduction carry) and #22
+    # (boundary input contracts) all should now turn clean. The vectors stay
+    # in the harness as a regression guard.
+    print("\nstructured regression vectors (post-#21 / #22: all should be clean):")
     regr = _run_cases([
+        # #21: scalar reduction carry
         ("smul", [2**256 - 1, N + 2], smul(2**256 - 1, N + 2)),                  # H-1
         ("sreduce", [N + 1, 0], sreduce(N + 1, 0)),                              # I-2 (same root cause)
-        ("sadd", [N, N], sadd(N, N)),                                           # M-1
-        ("sadd", [2**256 - 1, 2**256 - 1], sadd(2**256 - 1, 2**256 - 1)),       # M-1
+        # #22: scalar boundary
+        ("sadd", [N, N], sadd(N, N)),                                            # M-1
+        ("sadd", [2**256 - 1, 2**256 - 1], sadd(2**256 - 1, 2**256 - 1)),        # M-1
+        # #22: field boundary
+        ("fadd", [P - 1, P + 1], fadd(P - 1, P + 1)),                            # L-3
+        ("fneg", [P], fneg(P)),                                                  # I-3
+        ("fsub", [P - 1, P + 5], fsub(P - 1, P + 5)),                            # L-3
     ])
     for op, a, ex, got in regr:
         print(f"  DIVERGES {op}({', '.join(a)}): ref={ex} c={got}")
     if not regr:
-        print("  (none diverge — H-1/M-1 fixes appear to be in place)")
+        print("  (none diverge — all documented findings closed)")
 
     print(f"\nSUMMARY: in-contract mismatches={incontract}; "
-          f"known-defect vectors reproducing={len(regr)}/4")
+          f"regression vectors diverging={len(regr)}/7")
     sys.exit(1 if incontract else 0)

--- a/security/dfuzz_ref.py
+++ b/security/dfuzz_ref.py
@@ -224,4 +224,8 @@ if __name__ == "__main__":
 
     print(f"\nSUMMARY: in-contract mismatches={incontract}; "
           f"regression vectors diverging={len(regr)}/7")
-    sys.exit(1 if incontract else 0)
+    # Fail on either: a new in-contract mismatch (random pass), or a
+    # regression in any of the documented vectors (post-#21/#22 they must
+    # all stay clean).  The wrapper for `make check` / `run-checks.sh`
+    # treats a non-zero exit as FAIL.
+    sys.exit(1 if (incontract or regr) else 0)

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe 'Secp256k1Native' do
     it 'raises ArgumentError for negative input' do
       expect { n.fred(-1) }.to raise_error(ArgumentError)
     end
+
+    # L-1 also applies to fred — it packs 8 limbs directly (not via
+    # rb_to_uint256) so it needs its own guard.
+    it 'raises TypeError for non-Integer input [L-1]' do
+      expect { n.fred(1.5) }.to raise_error(TypeError, /Integer/)
+      expect { n.fred(Rational(3, 2)) }.to raise_error(TypeError, /Integer/)
+    end
   end
 
   describe '#fmul' do

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -520,6 +520,30 @@ RSpec.describe 'Secp256k1Native' do
     end
   end
 
+  # L-1 boundary contract: every public Secp256k1Native wrapper rejects
+  # non-Integer inputs with TypeError. The 256-bit wrappers share the guard
+  # at rb_to_uint256; rb_fred and rb_scalar_mod carry local guards because
+  # they don't flow through rb_to_uint256 (rb_fred packs 8 limbs;
+  # rb_scalar_mod dispatches Ruby `%` first). This shared block catches any
+  # future wrapper added without a guard.
+  describe 'L-1 boundary contract: every public wrapper rejects non-Integer' do
+    # method => arity
+    WRAPPERS_BY_ARITY = {
+      fred: 1, fmul: 2, fsqr: 1, fadd: 2, fsub: 2, fneg: 1, finv: 1, fsqrt: 1,
+      scalar_mod: 1, scalar_mul: 2, scalar_inv: 1, scalar_add: 2
+    }.freeze
+
+    WRAPPERS_BY_ARITY.each do |method, arity|
+      it "##{method} raises TypeError for non-Integer input" do
+        [1.5, '1', nil].each do |bad|
+          args = Array.new(arity, bad)
+          expect { n.send(method, *args) }.to raise_error(TypeError, /Integer/),
+            "expected Secp256k1Native.#{method}(#{args.inspect}) to raise TypeError"
+        end
+      end
+    end
+  end
+
   describe 'cross-validation: 100 random pairs vs Ruby reference' do
     it 'produces identical results for all field operations' do
       failures = []

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -154,6 +154,21 @@ RSpec.describe 'Secp256k1Native' do
     it 'is commutative' do
       expect(n.fadd(gx, gy)).to eq(n.fadd(gy, gx))
     end
+
+    # L-3: rb_fadd now pre-reduces operands; without the fix, fadd(P-1, P+1)
+    # returned exactly P (non-canonical).
+    it 'is correct for >= P operands [L-3 regression]' do
+      expect(n.fadd(p - 1, p + 1)).to eq(0)
+      expect(n.fadd(p, p)).to eq(0)
+      a = (1 << 256) - 1
+      expect(n.fadd(a, 1)).to eq((a + 1) % p)
+    end
+
+    it 'raises TypeError for non-Integer operands [L-1]' do
+      expect { n.fadd(1.5, 2) }.to raise_error(TypeError, /Integer/)
+      expect { n.fadd(2, 1.5) }.to raise_error(TypeError, /Integer/)
+      expect { n.fadd(nil, 2) }.to raise_error(TypeError, /Integer/)
+    end
   end
 
   describe '#fsub' do
@@ -176,6 +191,16 @@ RSpec.describe 'Secp256k1Native' do
 
     it 'matches the Ruby reference' do
       expect(n.fsub(gx, gy)).to eq(ref.fsub(gx, gy))
+    end
+
+    it 'is correct for >= P operands [L-3 regression]' do
+      expect(n.fsub(p, 0)).to eq(0)
+      a = (1 << 256) - 1
+      expect(n.fsub(a, p)).to eq((a - p) % p)
+    end
+
+    it 'raises TypeError for non-Integer operands [L-1]' do
+      expect { n.fsub(1.5, 2) }.to raise_error(TypeError, /Integer/)
     end
   end
 
@@ -202,6 +227,19 @@ RSpec.describe 'Secp256k1Native' do
 
     it 'satisfies a + neg(a) = 0' do
       expect(n.fadd(gx, n.fneg(gx))).to eq(0)
+    end
+
+    # I-3: rb_fneg now pre-reduces; without the fix fneg(P) was P (not 0)
+    # and fneg(>P) was wrong by an offset.
+    it 'is correct for >= P operand [I-3 regression]' do
+      expect(n.fneg(p)).to eq(0)
+      expect(n.fneg(p + 1)).to eq(p - 1)
+      a = (1 << 256) - 1
+      expect(n.fneg(a)).to eq((p - a % p) % p)
+    end
+
+    it 'raises TypeError for non-Integer input [L-1]' do
+      expect { n.fneg(1.5) }.to raise_error(TypeError, /Integer/)
     end
   end
 
@@ -297,12 +335,22 @@ RSpec.describe 'Secp256k1Native' do
 
     # Boundary band: values close to but under 2^256 exercise scalar_reduce's
     # final conditional subtract on hi=0, lo near the top of the 256-bit range.
-    # rb_scalar_mod rejects values >= 2^256, so 2*N etc. cannot be tested here
-    # — see the dfuzz harness for the hi != 0 case.
     it 'matches Integer#% for boundary values up to 2^256 - 1' do
       [curve_n + 2, curve_n + 100, (1 << 256) - 2, (1 << 256) - 1].each do |x|
         expect(n.scalar_mod(x)).to eq(x % curve_n), "x=#{x}"
       end
+    end
+
+    # L-4: rb_scalar_mod previously raised "exceeds 256 bits" for positive
+    # inputs >= 2^256 but accepted the negative counterpart. Now consistent.
+    it 'accepts large positive values >= 2^256 [L-4 regression]' do
+      expect(n.scalar_mod(2**600)).to eq(2**600 % curve_n)
+      expect(n.scalar_mod(2 * curve_n)).to eq(0)
+      expect(n.scalar_mod(2 * curve_n - 1)).to eq(curve_n - 1)
+    end
+
+    it 'raises TypeError for non-Integer input [L-1]' do
+      expect { n.scalar_mod(1.5) }.to raise_error(TypeError, /Integer/)
     end
 
     it 'matches the Ruby reference for a typical value' do
@@ -440,6 +488,22 @@ RSpec.describe 'Secp256k1Native' do
       a = gx % curve_n
       b = gy % curve_n
       expect(n.scalar_add(a, b)).to eq(ref.scalar_add(a, b))
+    end
+
+    # M-1 (medium): rb_scalar_add now pre-reduces operands. Without the fix,
+    # scalar_add_internal subtracted N at most once, so scalar_add(N, N)
+    # returned a non-canonical N (still in [0, N) but mathematically wrong).
+    # Random testing reaches this with probability ~2^-128 — these
+    # structured vectors are load-bearing.
+    it 'is correct for >= N operands [M-1 regression]' do
+      expect(n.scalar_add(curve_n, curve_n)).to eq(0)
+      a = (1 << 256) - 1
+      expect(n.scalar_add(a, a)).to eq((a + a) % curve_n)
+      expect(n.scalar_add(curve_n + 5, curve_n + 7)).to eq(12)
+    end
+
+    it 'raises TypeError for non-Integer operands [L-1]' do
+      expect { n.scalar_add(1.5, 2) }.to raise_error(TypeError, /Integer/)
     end
   end
 

--- a/spec/secp256k1_native_spec.rb
+++ b/spec/secp256k1_native_spec.rb
@@ -356,8 +356,14 @@ RSpec.describe 'Secp256k1Native' do
       expect(n.scalar_mod(2 * curve_n - 1)).to eq(curve_n - 1)
     end
 
+    # L-1: rb_scalar_mod dispatches Ruby `%` on the input as part of L-4's
+    # canonicalisation; without an Integer guard BEFORE the `%` call, a
+    # String would raise NoMethodError (not TypeError) and any object whose
+    # `%` happens to return an Integer would slip through.
     it 'raises TypeError for non-Integer input [L-1]' do
       expect { n.scalar_mod(1.5) }.to raise_error(TypeError, /Integer/)
+      expect { n.scalar_mod('123') }.to raise_error(TypeError, /Integer/)
+      expect { n.scalar_mod(nil) }.to raise_error(TypeError, /Integer/)
     end
 
     it 'matches the Ruby reference for a typical value' do

--- a/spec/secp256k1_spec.rb
+++ b/spec/secp256k1_spec.rb
@@ -193,8 +193,8 @@ RSpec.describe Secp256k1 do
       end
     end
 
-    describe '.new (I-3 mitigation: y-range guard)' do
-      it 'accepts valid x, y' do
+    describe '.new (I-3 mitigation: full-pair canonical guard)' do
+      it 'accepts a finite point with canonical coordinates' do
         expect(described_class.new(1, 2).y).to eq(2)
       end
 
@@ -203,20 +203,33 @@ RSpec.describe Secp256k1 do
       end
 
       # I-3: a non-canonical y stored in @y leaks through Point#negate
-      # (which calls fneg(y)) returning a non-canonical result. Closing
-      # at the constructor.
+      # (which calls fneg(y)) returning a non-canonical result. The full-
+      # pair guard also catches out-of-range x and nil/non-nil half-states
+      # so downstream paths (to_octet_string, on_curve?) can rely on the
+      # invariant that only (nil, nil) or two canonical Integers reach @x, @y.
       it 'raises ArgumentError for y >= P' do
-        expect { described_class.new(1, s::P) }.to raise_error(ArgumentError, /y must be/)
-        expect { described_class.new(1, s::P + 1) }.to raise_error(ArgumentError, /y must be/)
+        expect { described_class.new(1, s::P) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+        expect { described_class.new(1, s::P + 1) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
       end
 
-      it 'raises ArgumentError for negative y' do
-        expect { described_class.new(1, -1) }.to raise_error(ArgumentError, /y must be/)
+      it 'raises ArgumentError for x >= P' do
+        expect { described_class.new(s::P, 2) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
       end
 
-      it 'raises ArgumentError for non-Integer y' do
-        expect { described_class.new(1, 1.5) }.to raise_error(ArgumentError, /y must be/)
-        expect { described_class.new(1, '2') }.to raise_error(ArgumentError, /y must be/)
+      it 'raises ArgumentError for negative x or y' do
+        expect { described_class.new(1, -1) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+        expect { described_class.new(-1, 2) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+      end
+
+      it 'raises ArgumentError for non-Integer x or y' do
+        expect { described_class.new(1, 1.5) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+        expect { described_class.new(1, '2') }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+        expect { described_class.new(1.5, 2) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+      end
+
+      it 'raises ArgumentError for half-nil states (only one of x, y is nil)' do
+        expect { described_class.new(nil, 5) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
+        expect { described_class.new(5, nil) }.to raise_error(ArgumentError, /Integers in \[0, P\)/)
       end
     end
 

--- a/spec/secp256k1_spec.rb
+++ b/spec/secp256k1_spec.rb
@@ -193,6 +193,33 @@ RSpec.describe Secp256k1 do
       end
     end
 
+    describe '.new (I-3 mitigation: y-range guard)' do
+      it 'accepts valid x, y' do
+        expect(described_class.new(1, 2).y).to eq(2)
+      end
+
+      it 'accepts the point at infinity (nil, nil)' do
+        expect(described_class.new(nil, nil).infinity?).to be true
+      end
+
+      # I-3: a non-canonical y stored in @y leaks through Point#negate
+      # (which calls fneg(y)) returning a non-canonical result. Closing
+      # at the constructor.
+      it 'raises ArgumentError for y >= P' do
+        expect { described_class.new(1, s::P) }.to raise_error(ArgumentError, /y must be/)
+        expect { described_class.new(1, s::P + 1) }.to raise_error(ArgumentError, /y must be/)
+      end
+
+      it 'raises ArgumentError for negative y' do
+        expect { described_class.new(1, -1) }.to raise_error(ArgumentError, /y must be/)
+      end
+
+      it 'raises ArgumentError for non-Integer y' do
+        expect { described_class.new(1, 1.5) }.to raise_error(ArgumentError, /y must be/)
+        expect { described_class.new(1, '2') }.to raise_error(ArgumentError, /y must be/)
+      end
+    end
+
     describe '.from_bytes' do
       let(:g) { described_class.generator }
       let(:compressed) { g.to_octet_string(:compressed) }
@@ -303,6 +330,17 @@ RSpec.describe Secp256k1 do
           expect(g.mul(k)).to eq(g.mul_vt(k))
         end
       end
+
+      # L-2: pre-fix, Float scalars passed through `scalar.zero?` and
+      # `scalar %= N` (both valid for Float) then silently truncated in the
+      # native marshal.
+      it 'raises ArgumentError for Float scalar [L-2]' do
+        expect { g.mul(1.5) }.to raise_error(ArgumentError, /Integer/)
+      end
+
+      it 'raises ArgumentError for nil scalar [L-2]' do
+        expect { g.mul(nil) }.to raise_error(ArgumentError, /Integer/)
+      end
     end
 
     describe '#mul_ct (deprecated alias for #mul)' do
@@ -345,6 +383,14 @@ RSpec.describe Secp256k1 do
 
       it 'infinity * scalar = infinity' do
         expect(described_class.infinity.mul_vt(42).infinity?).to be true
+      end
+
+      it 'raises ArgumentError for Float scalar [L-2]' do
+        expect { g.mul_vt(1.5) }.to raise_error(ArgumentError, /Integer/)
+      end
+
+      it 'raises ArgumentError for nil scalar [L-2]' do
+        expect { g.mul_vt(nil) }.to raise_error(ArgumentError, /Integer/)
       end
     end
 

--- a/timing/ruby.h
+++ b/timing/ruby.h
@@ -45,7 +45,13 @@ extern VALUE rb_ary_entry(VALUE ary, long offset);
 /* Error class globals */
 extern VALUE rb_eRuntimeError;
 extern VALUE rb_eArgError;
+extern VALUE rb_eTypeError;
 extern VALUE rb_cInteger;
+
+/* Integer type predicate — the harness only feeds Integer-derived inputs, so
+ * the standalone-build stub treats every value as an Integer.  (Type-rejection
+ * is exercised by RSpec under the real CRuby runtime.) */
+#define RB_INTEGER_TYPE_P(v) 1
 
 /* Integer marshalling */
 extern int   rb_integer_pack(VALUE val, void *words, size_t numwords,

--- a/timing/ruby_stubs.c
+++ b/timing/ruby_stubs.c
@@ -27,6 +27,7 @@ typedef uintptr_t VALUE;
 VALUE rb_cInteger;
 VALUE rb_eRuntimeError;
 VALUE rb_eArgError;
+VALUE rb_eTypeError;
 
 /* Module handle declared extern in secp256k1_native.h */
 VALUE rb_mSecp256k1Native;


### PR DESCRIPTION
## Summary

Closes #22 — boundary input-contract hardening from the pre-v1.0 security review (`docs/security-review-v1.md` §3). None of the findings is reachable through the gem's own `Point` / SEC1 API, but consumers calling the primitives directly hit them.

- **M-1 (medium)** — `rb_scalar_add` now pre-reduces operands mod N. `scalar_add(N, N)` previously returned a non-canonical `N`; now returns `0`.
- **L-3 / I-3** — `rb_fadd` / `rb_fsub` / `rb_fneg` pre-reduce via `fred_internal`. `fadd(P-1, P+1)` previously returned `P`; now returns `0`. Pure-Ruby `fsub` / `fneg` canonicalise to match, so the dfuzz Ruby oracle agrees.
- **L-4** — `rb_scalar_mod` always applies Ruby `%`; positive ≥ 2²⁵⁶ inputs no longer raise inconsistently with their negative counterparts.
- **L-1** — `rb_to_uint256` rejects non-Integer with `TypeError` (one guard covers 15 wrappers); `rb_fred` carries its own guard (packs 8 limbs, doesn't flow through the helper — caught by the white-hat).
- **L-2** — `Point#mul` / `Point#mul_vt` reject non-Integer scalars with `ArgumentError` at the Ruby boundary. Extracted `normalise_scalar` helper to DRY both methods.
- **I-3 extension** — `Point#initialize` rejects y outside `[0, P)` per the source-report's mitigation.

Four conventional commits (B1 canonicalise / B2 type-reject / B3 tests+docs / white-hat fix). See [the synthesised breakdown comment](https://github.com/sgbett/secp256k1-native/issues/22#issuecomment-4840471849) on #22 for the per-task scope and conflict resolutions.

## Test plan

- [x] **394 / 394 RSpec pass** (+ 20 new regression tests: M-1 sadd(N,N), L-3 fadd(P-1, P+1), I-3 fneg(P), L-4 scalar_mod(2**600), L-1 TypeError across `fadd`/`fsub`/`fneg`/`fred`/`scalar_add`/`scalar_mod`, L-2 ArgumentError on `Point#mul(Float)` / `Point#mul(nil)`, I-3 mitigation on `Point.new(x, y≥P)`).
- [x] **Differential gate (`security/dfuzz_ref.py`)** — `regression vectors diverging=0/7`. All seven documented vectors (4 scalar from #21+M-1 + 3 field from L-3/I-3) now clean. `dfuzz_harness.c` mirrors the wrappers' pre-reduction so the harness tests post-wrapper semantics.
- [x] **ASan / UBSan sweep** — `PASS` (no sanitizer diagnostics, Docker).
- [x] **ctgrind secret-poisoning** (Docker on macOS ARM64) — `PASS: 0 errors`. No CT regression — the wrappers are off the hot path (ladder uses `_internal` functions directly via `jacobian.c`, performance specialist confirmed).

## Behaviour-change notes (no migration needed, but worth knowing)

- `Point#mul(Float)` and `Point#mul(nil)` now raise `ArgumentError` (was: silent truncation / `NoMethodError`).
- `Secp256k1Native.scalar_add(non-Integer, …)` etc. now raise `TypeError`.
- `Secp256k1Native.scalar_mod(2²⁵⁶ + …)` now accepted (was: `ArgumentError "exceeds 256 bits"`).
- `Point.new(x, y)` raises `ArgumentError` if y is given but not in `[0, P)`. Internal call sites (`mul`, `mul_vt`, `from_bytes`, etc.) all pass canonical y — verified.
- No CHANGELOG.md infrastructure introduced (the gem doesn't have one; v0.17.0 release notes were inline in the GitHub release).

## Specialist co-production

Five lenses ran in parallel; full synthesis in the [HLR comment](https://github.com/sgbett/secp256k1-native/issues/22#issuecomment-4840471849). Notable:
- **Pragmatic Enforcer vs Maintainability** on pure-Ruby `fsub`/`fneg` canonicalisation → keep (Pragmatic himself agreed: load-bearing as differential oracle parity).
- **Security Specialist's T2** (`from_bytes` Y=0 sanity check) → deferred to a separate follow-up — different attack vector.
- **White-hat gate caught the `rb_fred` L-1 bypass before this PR opened** (commit `8362646`); the broader claim "every wrapper rejects non-Integer" was technically false until that fix.

## Follow-up issues

- T2 — `from_bytes` Y=0 + prefix=0x03 sanity check (security specialist; to file post-merge).
- #29 — `bench:scalar` rake task (already filed).

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)