### PR TITLE
polish: API & contract hygiene (L-5 / L-6 / I-4 / I-5 / I-6)

### DIFF
--- a/docs/risks.md
+++ b/docs/risks.md
@@ -86,6 +86,16 @@ Given the evidence above, here is an honest assessment of where this gem's speci
 
 **Empirical constant-time verification.** The C extension's constant-time properties are empirically tested using a dudect-based timing harness (Welch's t-test, |t| < 4.5 threshold). Field arithmetic operations (`fred`, `fsub`, `fneg`, `fadd`) pass — their branchless conditional selection produces no detectable timing variation across 1.5 million measurements per function. The Montgomery ladder (`scalar_multiply_ct_internal`) passes at 10,000 measurements (|t| = 1.0). An earlier version had a measured timing leakage (|t| = 875) caused by early-return branches in `jp_add_internal` on `uint256_is_zero(&p[2])` (infinity checks). Inside the ladder, the accumulators start at infinity (Z=0), and how quickly they escaped this state depended on the scalar's bit pattern — undoing the constant-time property that the branchless `cswap` provided. The fix replaced branching `jp_add_internal` with a fully branchless implementation using mask-based `uint256_select` for all input-dependent special cases (infinity, equal points, negated points). The leakage was found by dudect, the root cause identified by code inspection, and the fix verified by dudect — a concrete demonstration of Principle 2 (empirical over inspected).
 
+### Constructing Point objects safely
+
+Coordinates that originate outside the gem — from a wire protocol, user input, or any source the caller does not already trust to be on-curve — must enter through one of the validating entry points:
+
+- `Secp256k1::Point.from_bytes(bytes)` for SEC1-encoded compressed (33 B) or uncompressed (65 B) input.
+- `Secp256k1::Point.from_coordinates(x, y)` for raw `(x, y)` Integers.
+- `Secp256k1::Point.generator` for the well-known generator G.
+
+All three validate `on_curve?` before returning. `Point.new(x, y)` is the underlying constructor used by `mul`, `add`, `negate`, and similar paths that produce always-on-curve intermediates — it validates only that the coordinates are Integers in `[0, P)`, not that they satisfy `y² = x³ + 7 (mod P)`. Calling `mul` on a Point built via `Point.new` with off-curve coordinates is an invalid-curve precondition; always prefer the validating entry points above for caller-supplied input. See [`security.md`](security.md#constructing-point-objects) for the same guidance from the API-safety angle.
+
 ## When to use this gem
 
 You need secp256k1 primitives in Ruby and:

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,6 +22,16 @@ point = pubkey.mul(public_hash)     # safe for public scalars too (just slower)
 point = pubkey.mul_vt(public_hash)  # faster, but only when scalar is public
 ```
 
+### Constructing `Point` objects
+
+Use one of these entry points for any `Point` instance you will later operate on with `mul` / `mul_vt`:
+
+- `Point.generator` — the well-known generator G.
+- `Point.from_bytes(bytes)` — SEC1 compressed (33 B) or uncompressed (65 B) deserialisation; validates `on_curve?` before returning.
+- `Point.from_coordinates(x, y)` — raw coordinates with `on_curve?` validation; the required entry point for caller-supplied coordinates from an external protocol or user input.
+
+`Point.new(x, y)` is the underlying constructor used by internal paths that *already know* the coordinates lie on the curve (`mul`, `add`, `negate`, etc.). It validates that x and y are Integers in `[0, P)` but does **not** verify curve membership. Calling `mul` on a Point built from off-curve coordinates is an invalid-curve precondition — always prefer `from_coordinates` for caller-supplied inputs (L-5).
+
 ### Pure-Ruby safety guard
 
 `mul` will raise `Secp256k1::InsecureOperationError` if the native C extension is not loaded. This prevents silent degradation to pure-Ruby arithmetic that cannot guarantee constant-time execution. `mul_vt` is unaffected — it is explicitly variable-time and does not claim constant-time properties.

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -458,7 +458,13 @@ int fsqrt_internal(uint256_t *r, const uint256_t *a)
         diff |= (check.d[i] ^ a_reduced.d[i]);
     }
 
-    if (diff != 0) return 0; /* not a quadratic residue */
+    if (diff != 0) {
+        /* Not a quadratic residue.  Honour the docstring contract by
+         * writing a defined value to *r so callers cannot inadvertently
+         * read uninitialised memory if they ignore the return code. */
+        uint256_copy(r, &zero);
+        return 0;
+    }
 
     uint256_copy(r, &result);
     return 1;

--- a/ext/secp256k1_native/field.c
+++ b/ext/secp256k1_native/field.c
@@ -199,7 +199,6 @@ void fred_internal(uint256_t *r, const uint256_t *hi, const uint256_t *lo)
 
     /* Compute c × hi with carry.  c fits in 33 bits, hi fits in 64 bits
      * each, so each product fits in 97 bits — safe in uint128_t. */
-    acc   = 0;
     carry = 0;
     for (i = 0; i < 4; i++) {
         acc       = (uint128_t)hi->d[i] * FRED_C + lo->d[i] + carry;

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -499,8 +499,9 @@ module Secp256k1
     # @param x [Integer] x-coordinate in [0, P)
     # @param y [Integer] y-coordinate in [0, P)
     # @return [Point]
-    # @raise [ArgumentError] if (x, y) is not on the curve, or if x or y
-    #   is not an Integer in [0, P) (raised by `new`)
+    # @raise [ArgumentError] if x or y is nil (use `Point.infinity` for
+    #   infinity); if x or y is not an Integer in [0, P) (raised by `new`);
+    #   or if (x, y) is not on the curve
     def self.from_coordinates(x, y)
       # Reject the (nil, nil) infinity shape that Point.new accepts. This
       # method's contract is "raw (x, y) Integers"; callers wanting infinity

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -502,6 +502,13 @@ module Secp256k1
     # @raise [ArgumentError] if (x, y) is not on the curve, or if x or y
     #   is not an Integer in [0, P) (raised by `new`)
     def self.from_coordinates(x, y)
+      # Reject the (nil, nil) infinity shape that Point.new accepts. This
+      # method's contract is "raw (x, y) Integers"; callers wanting infinity
+      # should use Point.infinity (or Point.new(nil, nil) on the internal path).
+      # Without this check, on_curve? returns true for infinity and we would
+      # silently return it.
+      raise ArgumentError, 'x and y must be Integers' if x.nil? || y.nil?
+
       pt = new(x, y)
       raise ArgumentError, 'point is not on the secp256k1 curve' unless pt.on_curve?
 

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -336,7 +336,7 @@ module Secp256k1
     tbl = WNAF_TABLE_CACHE[cache_key]
 
     if tbl.nil?
-      # Evict the oldest entry when the cache is full (simple LRU).
+      # FIFO eviction: drop the oldest *inserted* entry when the cache is full.
       WNAF_TABLE_CACHE.delete(WNAF_TABLE_CACHE.keys.first) if WNAF_TABLE_CACHE.size >= WNAF_CACHE_MAX
 
       tbl_size = 1 << (window - 1) # e.g. w=5 -> 16 entries

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -500,6 +500,15 @@ module Secp256k1
     # @raise [ArgumentError] if the encoding is invalid or the point
     #   is not on the curve
     def self.from_bytes(bytes)
+      # I-4: reject non-String / empty input up front with a clean
+      # ArgumentError. Without this, nil / Float / Integer raise
+      # NoMethodError (on `.encoding`), and an empty String raises
+      # NoMethodError (on `nil.to_s` in the else-branch error formatting).
+      # All fail closed either way, but the error type is wrong.
+      unless bytes.is_a?(String) && !bytes.empty?
+        raise ArgumentError, 'bytes must be a non-empty String'
+      end
+
       bytes = bytes.b if bytes.encoding != Encoding::BINARY
       prefix = bytes.getbyte(0)
 

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -307,7 +307,10 @@ module Secp256k1
 
   # @!visibility private
   # Cache for precomputed wNAF tables, keyed by "window:x:y".
-  # Evicts oldest entry when the LRU limit is reached.
+  # FIFO eviction: the oldest *inserted* entry is dropped when the cap
+  # is reached (Hash preserves insertion order; we delete the first key).
+  # Bounded at WNAF_CACHE_MAX entries; keyed only on the public base
+  # point — no secret-scalar exposure.
   WNAF_TABLE_CACHE = {} # rubocop:disable Style/MutableConstant
 
   # @!visibility private

--- a/lib/secp256k1.rb
+++ b/lib/secp256k1.rb
@@ -485,6 +485,29 @@ module Secp256k1
       new(nil, nil)
     end
 
+    # Construct a Point from raw (x, y) coordinates with curve-membership
+    # validation. This is the **required** entry point for caller-supplied
+    # coordinates (e.g. from an external protocol or user input).
+    #
+    # `Point.new` is intended for always-on-curve intermediates produced by
+    # `mul` / `mul_vt` / `add` / `negate`; it validates only the range of
+    # the coordinates, not that they satisfy y² = x³ + 7 (mod P). Calling
+    # `mul` on a Point constructed via `Point.new` with off-curve
+    # coordinates is an invalid-curve precondition that this method
+    # exists to close (L-5).
+    #
+    # @param x [Integer] x-coordinate in [0, P)
+    # @param y [Integer] y-coordinate in [0, P)
+    # @return [Point]
+    # @raise [ArgumentError] if (x, y) is not on the curve, or if x or y
+    #   is not an Integer in [0, P) (raised by `new`)
+    def self.from_coordinates(x, y)
+      pt = new(x, y)
+      raise ArgumentError, 'point is not on the secp256k1 curve' unless pt.on_curve?
+
+      pt
+    end
+
     # The generator point G.
     #
     # @return [Point]

--- a/spec/secp256k1_spec.rb
+++ b/spec/secp256k1_spec.rb
@@ -255,6 +255,21 @@ RSpec.describe Secp256k1 do
         expect { described_class.from_coordinates(1.5, 2) }
           .to raise_error(ArgumentError, /Integers in \[0, P\)/)
       end
+
+      # Without an explicit nil guard, Point.new(nil, nil) would succeed
+      # (infinity) and on_curve? would return true — silently returning
+      # infinity from a method documented as validating raw coordinates.
+      it 'raises ArgumentError for (nil, nil) — use Point.infinity instead' do
+        expect { described_class.from_coordinates(nil, nil) }
+          .to raise_error(ArgumentError, /x and y must be Integers/)
+      end
+
+      it 'raises ArgumentError for partial nil (x or y)' do
+        expect { described_class.from_coordinates(nil, 2) }
+          .to raise_error(ArgumentError, /x and y must be Integers/)
+        expect { described_class.from_coordinates(1, nil) }
+          .to raise_error(ArgumentError, /x and y must be Integers/)
+      end
     end
 
     describe '.from_bytes' do

--- a/spec/secp256k1_spec.rb
+++ b/spec/secp256k1_spec.rb
@@ -260,6 +260,18 @@ RSpec.describe Secp256k1 do
         expect { described_class.from_bytes("\u0004#{"\x00" * 63}") }.to raise_error(ArgumentError, /invalid uncompressed/)
       end
 
+      # I-4: previously these raised NoMethodError (on .encoding or
+      # nil.to_s) instead of ArgumentError.
+      it 'raises ArgumentError on non-String input [I-4]' do
+        expect { described_class.from_bytes(nil) }.to raise_error(ArgumentError, /non-empty String/)
+        expect { described_class.from_bytes(123) }.to raise_error(ArgumentError, /non-empty String/)
+        expect { described_class.from_bytes(1.5) }.to raise_error(ArgumentError, /non-empty String/)
+      end
+
+      it 'raises ArgumentError on empty String [I-4]' do
+        expect { described_class.from_bytes('') }.to raise_error(ArgumentError, /non-empty String/)
+      end
+
       it 'raises on point not on curve' do
         bad = "\x04".b + s.int_to_bytes(1, 32) + s.int_to_bytes(2, 32)
         expect { described_class.from_bytes(bad) }.to raise_error(ArgumentError, /not on the curve/)

--- a/spec/secp256k1_spec.rb
+++ b/spec/secp256k1_spec.rb
@@ -233,6 +233,30 @@ RSpec.describe Secp256k1 do
       end
     end
 
+    describe '.from_coordinates (L-5: caller-supplied coordinates)' do
+      let(:g) { described_class.generator }
+
+      it 'returns a Point for on-curve coordinates' do
+        pt = described_class.from_coordinates(g.x, g.y)
+        expect(pt).to eq(g)
+      end
+
+      it 'raises ArgumentError for off-curve coordinates' do
+        expect { described_class.from_coordinates(1, 2) }
+          .to raise_error(ArgumentError, /not on the secp256k1 curve/)
+      end
+
+      it 'raises ArgumentError for out-of-range coordinates (delegated to new)' do
+        expect { described_class.from_coordinates(s::P, g.y) }
+          .to raise_error(ArgumentError, /Integers in \[0, P\)/)
+      end
+
+      it 'raises ArgumentError for non-Integer coordinates' do
+        expect { described_class.from_coordinates(1.5, 2) }
+          .to raise_error(ArgumentError, /Integers in \[0, P\)/)
+      end
+    end
+
     describe '.from_bytes' do
       let(:g) { described_class.generator }
       let(:compressed) { g.to_octet_string(:compressed) }


### PR DESCRIPTION
## Summary

Five small polish fixes from the pre-v1.0 security review (`docs/security-review-v1.md` §3). All explicitly non-blocking and not reachable as vulnerabilities; pure robustness / "don't surprise a future caller" items.

- **L-5** — `Point.from_coordinates(x, y)` added: the required entry point for caller-supplied coordinates. Validates `on_curve?` after `Point.new`'s range guard; closes the hypothetical invalid-curve precondition where downstream code calls `Point.new` on attacker-supplied coordinates and then `mul` on a secret scalar.
- **L-6** — `fsqrt_internal` now writes a defined value (zero) to `*r` on the non-residue path, honouring its docstring contract. No in-tree caller depends on this today (`from_bytes` checks the return code), but the docstring promised it.
- **I-4** — `Point.from_bytes` raises a clean `ArgumentError` on `nil` / `Float` / `Integer` / empty `String` input (was: `NoMethodError` on `.encoding` or `nil.to_s`).
- **I-5** — wNAF cache comment corrected from "LRU" to FIFO (the implementation drops the oldest *inserted* entry, not the least-recently-*used* one). Public-scalar-only, 512-entry bound — keeping FIFO; not implementing true LRU.
- **I-6** — dead store `acc = 0;` in `fred_internal` removed (immediately overwritten on the first loop iteration).

Five conventional commits, one per finding.

## Test plan

- [x] **414/414 RSpec pass** (+ 10 new tests: 6 for `Point.from_coordinates`, 4 for `from_bytes` non-String/empty rejection).
- [x] **Differential gate** — `regression vectors diverging=0/7` (unchanged from master).
- [x] **Compile clean** on Ruby 3.4 / macOS clang.

## Notes

- `Point.new` is intentionally left as-is. `mul` / `add` / `negate` / `from_bytes` produce always-on-curve intermediates and shouldn't pay the `on_curve?` cost on every internal construction. `docs/security.md` gains a "Constructing Point objects" subsection that spells this out.
- I-5: implementing true LRU would touch every cache lookup (re-order on hit); the FIFO behaviour is correct for the cache's role and the comment was the only thing wrong.
- L-6: zero is a natural sentinel; reuses the existing `zero` local already in scope.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)