### PR TITLE
ci: add main.yml permissions and roll in dependabot bumps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         run: bundle exec rake docs:lint
       - name: Proofread internal links
         run: bundle exec rake docs:proofread
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,4 +65,4 @@ jobs:
 
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601  # v1.315.0
         with:
           ruby-version: '3.4'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: bundle exec rake docs:proofread
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: docs/_site

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,12 @@ on:
 
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
           - '3.4'
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601  # v1.315.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           - '3.4'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7.0.0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 4.3'
 gem 'just-the-docs', '0.12.0'
 gem 'jekyll-redirect-from', '0.16.0'
-gem 'jekyll-relative-links', '0.6.1'
+gem 'jekyll-relative-links', '0.7.0'
 
 group :development do
   gem 'webrick'  # Ruby 3.0+ stdlib removal — needed for `jekyll serve`

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-relative-links (0.6.1)
+    jekyll-relative-links (0.7.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
@@ -241,7 +241,7 @@ DEPENDENCIES
   html-proofer
   jekyll (~> 4.3)
   jekyll-redirect-from (= 0.16.0)
-  jekyll-relative-links (= 0.6.1)
+  jekyll-relative-links (= 0.7.0)
   just-the-docs (= 0.12.0)
   webrick
 
@@ -292,7 +292,7 @@ CHECKSUMS
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
-  jekyll-relative-links (0.6.1) sha256=d11301f57b39e94b6c04fff2a3b145fe2f6a27be631a403e2542fa2e1548dd6d
+  jekyll-relative-links (0.7.0) sha256=831e54c348eeae751845c0d4ac4b244bd73b664341f0e8c9f1803b16f4570835
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1


### PR DESCRIPTION
## Summary

Closes the CodeQL `actions/missing-workflow-permissions` alert on `main.yml` and rolls in the five Dependabot bumps that landed after PR #44 merged — the pages-Actions bumps also close the Node.js 20 deprecation warning that appeared on that PR's deploy job.

### Commits

| SHA | What | File(s) |
|---|---|---|
| `81baf7f` | `main.yml` gets workflow-level `permissions: {}` and job-scoped `contents: read` on `build` (same pattern as `docs.yml`) | `.github/workflows/main.yml` |
| `86aaa13` | actions/deploy-pages 4.0.5 → 5.0.0 (Node.js 24) | `.github/workflows/docs.yml` |
| `bda1c38` | actions/configure-pages 5.0.0 → 6.0.0 (Node.js 24) | `.github/workflows/docs.yml` |
| `c6a95e1` | actions/checkout 5.0.1 → 7.0.0 (blocks fork PR checkout under `pull_request_target`/`workflow_run` — additional foot-gun mitigation) | `.github/workflows/main.yml`, `.github/workflows/docs.yml` |
| `f7b2791` | actions/upload-pages-artifact 3.0.1 → 5.0.0 (Node.js 24, internal upload-artifact v7) | `.github/workflows/docs.yml` |
| `29a414f` | jekyll-relative-links 0.6.1 → 0.7.0 (adds "links with titles" handling) | `docs/Gemfile`, `docs/Gemfile.lock` |

## Closes

- Closes #45
- Supersedes #46, #47, #48, #49, #50 (Dependabot PRs — cherry-picked here so we ship one PR, one deploy)

## Test plan

- [x] `bundle exec rake docs:build` green (Jekyll site builds with jekyll-relative-links 0.7.0)
- [x] `bundle exec rake docs:lint` green (11 files OK)
- [x] `bundle exec rake docs:proofread` green (13 files, ~170 internal links)
- [x] `ruby -ryaml -e "YAML.load_file(...)"` on both workflow files — both parse clean
- [ ] CI: Ruby matrix 2.7 → 3.4 green under the new `permissions: contents: read` and `actions/checkout@v7`
- [ ] CI: docs `build` job green under bumped pages actions (Node.js 24 — should resolve the deprecation warning)
- [ ] CodeQL alert #1 auto-closes on next scan after merge

## Notes

- The docs deploy job is gated on `if: github.event_name == 'push' && github.ref == 'refs/heads/master'` — PR runs the build only, no deploy. Verify against post-merge master run.
- Rollback: individual commits are independent; a bad bump can be reverted with `git reset` (project standard forbids `git revert`) without touching the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
