### PR TITLE
fix(gemspec): narrow lib glob to .rb only (packaging wart)

### DIFF
--- a/secp256k1-native.gemspec
+++ b/secp256k1-native.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ['ext/secp256k1_native/extconf.rb']
 
-  spec.files = Dir.glob('lib/**/*') +
+  spec.files = Dir.glob('lib/**/*.rb') +
                Dir.glob('ext/**/*.{c,h,rb}') +
                ['secp256k1-native.gemspec', 'LICENSE', 'README.md', 'CHANGELOG.md']
 


### PR DESCRIPTION
## Summary

One-line gemspec fix for HLR #37. `Dir.glob('lib/**/*')` picked up any locally-compiled extension binary (`lib/secp256k1_native.bundle` on macOS, `.so` on Linux) into the published gem, even though `extconf.rb` rebuilds the extension at install time on the target machine. Result: the shipped binary was shadowed and just dead weight (e.g. an arm64 `.bundle` inside a gem installed on Linux). Not a functional bug — RubyGems rebuilds via `extconf.rb` anyway — but a packaging wart.

Narrow the glob to `lib/**/*.rb` per the HLR's preferred form.

## Closes

- Closes #37

## Test plan

- [x] `bundle exec rake compile` produces `lib/secp256k1_native.bundle` (dev-built)
- [x] `gem build secp256k1-native.gemspec` from a tree WITH `.bundle` present → gem contains exactly 12 files (source/docs only, no compiled artefacts)
- [x] Removed `.bundle`, `gem build` again → identical file list (`diff` returns empty)
- [x] `bundle exec rake compile && bundle exec rspec` → 416 examples, 0 failures
- [x] Grep for `\.(bundle|so|dll)$` in the extracted `data.tar.gz` → no matches
- [ ] CI green

## Notes

- This ships in the next release (probably v0.19.0); the shipped v0.18.0 gem retains the wart per the HLR's acknowledgement that it's not urgent.
- Alternative form considered (`.reject { |f| f.match?(/\.(bundle|so|dll)$/) }`) — the HLR preferred `.rb`-only for clearer intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
