### PR TITLE
hardening: complete H-2 structural controls (source grep, assembly invariant, release checklist)

### DIFF
--- a/.github/workflows/ct-assembly-invariant.yml
+++ b/.github/workflows/ct-assembly-invariant.yml
@@ -1,0 +1,55 @@
+name: CT assembly invariant
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'ext/**'
+      - 'security/check-ct-assembly.rb'
+      - '.github/workflows/ct-assembly-invariant.yml'
+  pull_request:
+    paths:
+      - 'ext/**'
+      - 'security/check-ct-assembly.rb'
+      - '.github/workflows/ct-assembly-invariant.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    name: Ladder loop body invariant
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601  # v1.315.0
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Install binutils (objdump)
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends binutils
+
+      # Compile jacobian.c at the shipping optimisation level (-O2) with
+      # debug info so `objdump -dl` can attribute lines. The rest of the
+      # flag set mirrors ext/secp256k1_native/extconf.rb: -Wall -std=c99,
+      # plus -fcommon (needed by GCC 10+ against the extension's linkage
+      # style, matches security/Makefile).
+      - name: Compile jacobian.c at -O2 -g
+        run: |
+          RUBY_HDR_DIR=$(ruby -e 'puts RbConfig::CONFIG["rubyhdrdir"]')
+          RUBY_ARCH_HDR_DIR=$(ruby -e 'puts RbConfig::CONFIG["rubyarchhdrdir"]')
+          gcc -O2 -g -Wall -std=c99 -fcommon \
+              -I ext/secp256k1_native \
+              -I "$RUBY_HDR_DIR" \
+              -I "$RUBY_ARCH_HDR_DIR" \
+              -c ext/secp256k1_native/jacobian.c \
+              -o /tmp/jacobian.o
+
+      - name: Assert ladder loop body invariant
+        run: ruby security/check-ct-assembly.rb /tmp/jacobian.o

--- a/.github/workflows/ct-assembly-invariant.yml
+++ b/.github/workflows/ct-assembly-invariant.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   check:
-    name: Ladder loop body invariant
+    name: CT assembly invariant (ladder + jp_add_internal)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,16 +40,24 @@ jobs:
       # flag set mirrors ext/secp256k1_native/extconf.rb: -Wall -std=c99,
       # plus -fcommon (needed by GCC 10+ against the extension's linkage
       # style, matches security/Makefile).
-      - name: Compile jacobian.c at -O2 -g
+      #
+      # `-fno-stack-protector` is added strictly for this CI check — it removes
+      # GCC's `sub %fs:0x28,%rax; jne <__stack_chk_fail>` epilogue artefact from
+      # canary-protected functions. That `jne` is data-independent (canary vs
+      # canary), not a CT concern, but it inflates the conditional-jump count
+      # in the `jp_add_internal` invariant. Stripping the canary here lets the
+      # check inspect exactly the CT-relevant control flow. Shipping continues
+      # to be built with `-fstack-protector-strong` per Ruby's mkmf defaults.
+      - name: Compile jacobian.c at -O2 -g (no stack protector — CT-only view)
         run: |
           RUBY_HDR_DIR=$(ruby -e 'puts RbConfig::CONFIG["rubyhdrdir"]')
           RUBY_ARCH_HDR_DIR=$(ruby -e 'puts RbConfig::CONFIG["rubyarchhdrdir"]')
-          gcc -O2 -g -Wall -std=c99 -fcommon \
+          gcc -O2 -g -Wall -std=c99 -fcommon -fno-stack-protector \
               -I ext/secp256k1_native \
               -I "$RUBY_HDR_DIR" \
               -I "$RUBY_ARCH_HDR_DIR" \
               -c ext/secp256k1_native/jacobian.c \
               -o /tmp/jacobian.o
 
-      - name: Assert ladder loop body invariant
+      - name: Assert ladder loop body + jp_add_internal branchlessness
         run: ruby security/check-ct-assembly.rb /tmp/jacobian.o

--- a/.github/workflows/ct-assembly-invariant.yml
+++ b/.github/workflows/ct-assembly-invariant.yml
@@ -30,7 +30,8 @@ jobs:
         uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601  # v1.315.0
         with:
           ruby-version: '3.4'
-          bundler-cache: true
+          # No bundler-cache: this job runs a standalone stdlib-only Ruby
+          # script and never invokes `bundle exec`.
 
       - name: Install binutils (objdump)
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends binutils

--- a/.github/workflows/ct-assembly-invariant.yml
+++ b/.github/workflows/ct-assembly-invariant.yml
@@ -33,8 +33,12 @@ jobs:
           # No bundler-cache: this job runs a standalone stdlib-only Ruby
           # script and never invokes `bundle exec`.
 
-      - name: Install binutils (objdump)
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends binutils
+      # binutils (objdump) is preinstalled on ubuntu-latest — only fall back
+      # to apt-get if a future image drops it. Skips `apt-get update` entirely
+      # so a broken upstream repo (e.g. packages.microsoft.com returning an
+      # unsigned InRelease, as happened 2026-07-07) can't red the CT gate.
+      - name: Ensure objdump available
+        run: command -v objdump || sudo apt-get install -y --no-install-recommends binutils
 
       # Compile jacobian.c at the shipping optimisation level (-O2) with
       # debug info so `objdump -dl` can attribute lines. The rest of the

--- a/.github/workflows/ct-source-guard.yml
+++ b/.github/workflows/ct-source-guard.yml
@@ -24,5 +24,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Guard against raw -(uint{32,64}_t)( mask construction
+      - name: 'Guard: no raw -(uint32_t) / -(uint64_t) mask construction outside ct_value_barrier_u64'
         run: bash security/check-ct-mask-guard.sh

--- a/.github/workflows/ct-source-guard.yml
+++ b/.github/workflows/ct-source-guard.yml
@@ -1,0 +1,28 @@
+name: CT source guard
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'ext/**'
+      - 'security/check-ct-mask-guard.sh'
+      - '.github/workflows/ct-source-guard.yml'
+  pull_request:
+    paths:
+      - 'ext/**'
+      - 'security/check-ct-mask-guard.sh'
+      - '.github/workflows/ct-source-guard.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Guard against raw -(uint64_t)( mask construction
+        run: bash security/check-ct-mask-guard.sh

--- a/.github/workflows/ct-source-guard.yml
+++ b/.github/workflows/ct-source-guard.yml
@@ -24,5 +24,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Guard against raw -(uint64_t)( mask construction
+      - name: Guard against raw -(uint{32,64}_t)( mask construction
         run: bash security/check-ct-mask-guard.sh

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,12 @@ Style/FrozenStringLiteralComment:
 
 # security/ contains standalone analysis harnesses (dfuzz, ctgrind, asan,
 # check-ct-assembly, ...). They are single-file scripts, not library code;
-# the Metrics/* cops fight their natural shape (a `main`, a handful of
-# helpers). Filenames use hyphens for consistency with the sibling shell
-# scripts (check-ct-mask-guard.sh). Keep the style-affecting cops on, relax
-# the size-metric and filename ones.
+# the entire Metrics/* department (block/method/class length, AbcSize,
+# cyclomatic and perceived complexity, parameter lists) fights their
+# natural shape — a `main`, a handful of helpers, one or two long parser
+# regexes. Filenames use hyphens for consistency with the sibling shell
+# scripts (e.g. check-ct-mask-guard.sh), which Naming/FileName also flags.
+# All style-affecting cops (Style/*, Layout/*, Lint/*) stay on.
 Metrics:
   Exclude:
     - 'security/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,10 @@ Metrics:
 Naming/FileName:
   Exclude:
     - 'security/**/*.rb'
+
+# The `check_ladder` / `check_jp_add_internal` methods return true/false but
+# also emit PASS/FAIL diagnostics as their primary product — they are not
+# pure predicates. The `?` suffix would misrepresent their contract.
+Naming/PredicateMethod:
+  Exclude:
+    - 'security/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,17 @@ Style/StringLiterals:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+
+# security/ contains standalone analysis harnesses (dfuzz, ctgrind, asan,
+# check-ct-assembly, ...). They are single-file scripts, not library code;
+# the Metrics/* cops fight their natural shape (a `main`, a handful of
+# helpers). Filenames use hyphens for consistency with the sibling shell
+# scripts (check-ct-mask-guard.sh). Keep the style-affecting cops on, relax
+# the size-metric and filename ones.
+Metrics:
+  Exclude:
+    - 'security/**/*.rb'
+
+Naming/FileName:
+  Exclude:
+    - 'security/**/*.rb'

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,7 +5,7 @@ nav_order: 9
 
 # Releasing
 
-Pre-tag checklist. This is a literal gate — each box has to be ticked *before* the tag is pushed. The H-2 leak shipped precisely because a narrative-only "bare-metal dudect is required" prose gate lapsed between 0.17.0 and v1; codifying it here so a future release cannot silently skip it.
+This is the pre-tag checklist — a literal gate where each box has to be ticked *before* the tag is pushed. The H-2 leak shipped precisely because a narrative-only "bare-metal dudect is required" prose gate lapsed between 0.17.0 and v1, and this document codifies that gate so a future release cannot silently skip it.
 
 ## Pre-tag checklist
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,34 @@
+---
+title: Releasing
+nav_order: 9
+---
+
+# Releasing
+
+Pre-tag checklist. This is a literal gate — each box has to be ticked *before* the tag is pushed. The H-2 leak shipped precisely because a narrative-only "bare-metal dudect is required" prose gate lapsed between 0.17.0 and v1; codifying it here so a future release cannot silently skip it.
+
+## Pre-tag checklist
+
+- [ ] CI all green (Ruby matrix × CodeQL × tests × docs).
+- [ ] `bundle exec rspec` green locally.
+- [ ] Differential gate (`security/run-checks.sh`) — `regression vectors diverging = 0/7`.
+- [ ] ctgrind clean (Docker on macOS, native on Linux).
+- [ ] **Bare-metal dudect run on the reference hardware** — see the [timing verification runbook](timing-verification-runbook.md). Record CPU / microcode / kernel / compiler + per-op |t| in [`docs/security.md`](security.md) (and [`docs/risks.md`](risks.md) if the result materially changes the CT claim).
+- [ ] **Re-run bare-metal dudect if the pinned/known-good compiler version changed** since the last release.
+- [ ] CHANGELOG `[Unreleased]` section closed out with the tag date.
+- [ ] If the release fixes a security finding: in-repo advisory `Patched in` line updated; GHSA published; CVE requested via the GHSA flow.
+
+## Why bare-metal dudect is the load-bearing step
+
+`ctgrind` observes the *source-level* CT contract on the CI toolchain; bare-metal dudect observes the *statistical timing of the shipping binary* on the known-good compiler. Between them these cover the two failure modes H-2 exposed:
+
+- **Source-level regression** — a contributor introducing a new branch. Caught by CI (`security/check-ct-mask-guard.sh`, ctgrind, RSpec).
+- **Compiler-level regression** — the compiler reconstructing a branch from branchless source. Caught only by bare-metal dudect on the shipping compiler.
+
+The assembly-invariant CI check (`.github/workflows/ct-assembly-invariant.yml`) narrows the gap by observing binary *structure* on every commit, but the shipping binary's *statistical timing* is a superset — bare-metal dudect on the release compiler stays required.
+
+## Related
+
+- Security discipline overview: [Security](security.md)
+- Runbook: [Timing verification runbook](timing-verification-runbook.md)
+- Structural controls: umbrella issue #54 (source grep, assembly check, this checklist)

--- a/docs/security.md
+++ b/docs/security.md
@@ -155,6 +155,8 @@ A non-isolated desktop (live GUI session, no `isolcpus` core reservation) also r
 
 The GCC 15 finding makes the policy explicit: **"passes ctgrind in CI" is not sufficient on its own to ship a release.** A compiler upgrade — or a change in flags, target, or even an inlining decision — can silently reconstruct a branch from branchless source, and only the statistical, bare-metal dudect pass observes the *compiled* timing. The deterministic check would have caught this one (it did), but it runs against whatever toolchain CI happens to use; the timing that ships is the timing on the user's compiler. Therefore the bare-metal dudect run in the [runbook](timing-verification-runbook.md) is a **required gate before tagging a release**, re-run whenever the pinned/known-good compiler version changes — not a one-off for issue #25.
 
+See [Releasing](RELEASING.md) for the literal pre-tag checklist that makes this an explicit gate rather than narrative prose.
+
 ### Variable-time paths
 
 The wNAF scalar multiplication loop (`scalar_multiply_wnaf`, exposed as `Point#mul_vt`) branches on scalar bits and uses a precomputed table with data-dependent lookups. It is explicitly variable-time. This is acceptable for public scalars (signature verification) but must never be used with secret scalars.

--- a/security/check-ct-assembly.rb
+++ b/security/check-ct-assembly.rb
@@ -293,14 +293,20 @@ end
 
 def check_ladder(disasm, input_path)
   body = symbol_body(disasm, LADDER_SYMBOL)
-  die("symbol `#{LADDER_SYMBOL}` not found in `#{input_path}` -- was it compiled from jacobian.c?") if body.nil?
+  if body.nil?
+    warn "check-ct-assembly: FAIL -- symbol `#{LADDER_SYMBOL}` not found in `#{input_path}` -- " \
+         'was it compiled from jacobian.c?'
+    return false
+  end
 
   cond_jumps = collect_cond_jumps(body)
   cmovs = collect_cmovs(body)
   range = find_loop_range(body, cond_jumps)
   if range.nil?
-    die("could not locate ladder loop in `#{LADDER_SYMBOL}` -- no backward conditional jump found. " \
-        'Codegen may have changed shape (unrolled?). Inspect objdump -dl output manually.')
+    warn "check-ct-assembly: FAIL -- could not locate ladder loop in `#{LADDER_SYMBOL}` -- " \
+         'no backward conditional jump found. Codegen may have changed shape (unrolled?). ' \
+         'Inspect objdump -dl output manually.'
+    return false
   end
 
   top_addr, bottom_addr = range

--- a/security/check-ct-assembly.rb
+++ b/security/check-ct-assembly.rb
@@ -28,17 +28,31 @@
 #
 # Scope of the check
 # ------------------
-# Symbol: scalar_multiply_ct_internal.
-# Region: the trailing backward-branching loop (its target is the loop top,
-#   its own address is the bottom).
-# Failure conditions inside that region:
-#   1. more than one conditional-jump mnemonic (j<cond>), OR
-#   2. any conditional-move mnemonic (cmov<cond>).
+# Two symbols are inspected:
 #
-# The check is deliberately scoped to the ladder loop body because that is
-# the primitive whose *structural* branchlessness the CT contract depends on.
-# Adjacent guards (#34 grep, dudect gate) cover the callee `jp_add_internal`
-# where H-2's `uint256_select` calls compile.
+#   1. scalar_multiply_ct_internal — the Montgomery ladder driver.
+#      Region: the trailing backward-branching loop (its target is the loop
+#      top, its own address is the bottom).
+#      Failure conditions inside that region:
+#        (a) more than one conditional-jump mnemonic (j<cond>), OR
+#        (b) any conditional-move mnemonic (cmov<cond>).
+#      The single legitimate conditional jump is the loop counter's back-edge.
+#
+#   2. jp_add_internal — the branchless Jacobian point addition. In source
+#      it is deliberately mask-based end-to-end (see docstring in jacobian.c).
+#      H-2 was exactly the shape where GCC 15.2 reconstructed a data-dependent
+#      branch inside a `uint256_select` call that lands in this function, so
+#      inspecting the standalone symbol closes the coverage gap where the
+#      ladder-loop check would miss non-inlined regressions here.
+#      Failure conditions inside the whole body:
+#        (a) any conditional-jump mnemonic (j<cond>), OR
+#        (b) any conditional-move mnemonic (cmov<cond>).
+#      Unconditional jmp / call / ret are all permitted.
+#
+# If the compiler inlines jp_add_internal into the ladder, its standalone
+# symbol is absent from objdump output; the checker emits a NOTE and treats
+# that as PASS — the inlined body sits inside the ladder loop and is covered
+# by the loop-body check instead.
 #
 # Platform scoping
 # ----------------
@@ -60,7 +74,8 @@
 require 'open3'
 require 'shellwords'
 
-SYMBOL = 'scalar_multiply_ct_internal'
+LADDER_SYMBOL = 'scalar_multiply_ct_internal'
+JP_ADD_SYMBOL = 'jp_add_internal'
 
 # Conditional-jump mnemonic pattern. On x86-64 AT&T syntax the family is
 # `j<cond>` for cond in {e, ne, z, nz, b, be, nb, a, ae, na, nae, l, le, g,
@@ -202,8 +217,31 @@ def report_pass(top_addr, bottom_addr, loop_jumps)
   lo = format('%#x', top_addr)
   hi = format('%#x', bottom_addr)
   addr, mnem, = loop_jumps.first
-  puts "check-ct-assembly: PASS -- #{SYMBOL} loop body [#{lo}..#{hi}] " \
+  puts "check-ct-assembly: PASS -- #{LADDER_SYMBOL} loop body [#{lo}..#{hi}] " \
        "contains exactly 1 conditional jump (#{format('%#x', addr)}: #{mnem}) and 0 cmov."
+end
+
+def report_pass_jp_add(range)
+  lo, hi = range
+  puts "check-ct-assembly: PASS -- #{JP_ADD_SYMBOL} body " \
+       "[#{format('%#x', lo)}..#{format('%#x', hi)}] fully branchless " \
+       '(0 conditional jumps, 0 cmov).'
+end
+
+def report_fail_jp_add(body, cond_jumps, cmovs)
+  warn "check-ct-assembly: FAIL -- #{JP_ADD_SYMBOL} contains a data-dependent branch."
+  cond_jumps.each do |addr, mnem, target|
+    warn "  #{format('%#x', addr)}: #{mnem} -> #{format('%#x', target)}"
+  end
+  cmovs.each { |addr, mnem| warn "  #{format('%#x', addr)}: #{mnem}" }
+  warn ''
+  warn "#{JP_ADD_SYMBOL} is required to be end-to-end mask-based (see docstring in"
+  warn 'ext/secp256k1_native/jacobian.c). This is the exact shape of the H-2 regression'
+  warn '(GHSA-vp2j-gqfm-r3cf): GCC 15.2 reconstructed a data-dependent branch inside'
+  warn 'a `uint256_select` call that landed here. Confirm `ct_value_barrier_u64` still'
+  warn 'applies inside `ct_mask_u64` and inspect the disassembly below:'
+  warn ''
+  body.each { |l| warn "  #{l.chomp}" }
 end
 
 def report_fail(problems, body_lines, top_addr, bottom_addr)
@@ -218,6 +256,29 @@ def report_fail(problems, body_lines, top_addr, bottom_addr)
   warn 'new helper in the ladder path constructs a mask outside `ct_mask_u64`.'
 end
 
+# Inspect jp_add_internal. Returns true on pass (or graceful "symbol not
+# present" NOTE — likely inlined), false on fail.
+def check_jp_add_internal(disasm)
+  body = symbol_body(disasm, JP_ADD_SYMBOL)
+  if body.nil?
+    puts "check-ct-assembly: NOTE -- `#{JP_ADD_SYMBOL}` symbol absent from " \
+         'objdump output; likely inlined into the ladder. Its body is covered ' \
+         "by the #{LADDER_SYMBOL} loop-body check."
+    return true
+  end
+
+  cond_jumps = collect_cond_jumps(body)
+  cmovs = collect_cmovs(body)
+
+  if cond_jumps.empty? && cmovs.empty?
+    report_pass_jp_add(symbol_address_range(body))
+    return true
+  end
+
+  report_fail_jp_add(body, cond_jumps, cmovs)
+  false
+end
+
 def check_host_arch!
   host = RbConfig::CONFIG['host_cpu'] || RUBY_PLATFORM
   return if host.include?('x86_64') || host.include?('amd64')
@@ -225,20 +286,15 @@ def check_host_arch!
   skip("host CPU `#{host}` is not x86_64; this check targets GCC x86_64 codegen")
 end
 
-def main(argv)
-  input = argv[0] || '/tmp/jacobian.o'
-  die("input object file `#{input}` not found") unless File.file?(input)
-  check_host_arch!
-
-  disasm = objdump_disassembly(input)
-  body = symbol_body(disasm, SYMBOL)
-  die("symbol `#{SYMBOL}` not found in `#{input}` (was it compiled from jacobian.c?)") if body.nil?
+def check_ladder(disasm)
+  body = symbol_body(disasm, LADDER_SYMBOL)
+  die("symbol `#{LADDER_SYMBOL}` not found -- was #{ENV['ARGV0'] || 'the object file'} compiled from jacobian.c?") if body.nil?
 
   cond_jumps = collect_cond_jumps(body)
   cmovs = collect_cmovs(body)
   range = find_loop_range(body, cond_jumps)
   if range.nil?
-    die("could not locate ladder loop in `#{SYMBOL}` -- no backward conditional jump found. " \
+    die("could not locate ladder loop in `#{LADDER_SYMBOL}` -- no backward conditional jump found. " \
         'Codegen may have changed shape (unrolled?). Inspect objdump -dl output manually.')
   end
 
@@ -249,11 +305,22 @@ def main(argv)
 
   if problems.empty?
     report_pass(top_addr, bottom_addr, loop_jumps)
-    exit 0
+    return true
   end
 
   report_fail(problems, body, top_addr, bottom_addr)
-  exit 1
+  false
+end
+
+def main(argv)
+  input = argv[0] || '/tmp/jacobian.o'
+  die("input object file `#{input}` not found") unless File.file?(input)
+  check_host_arch!
+
+  disasm = objdump_disassembly(input)
+  ladder_ok = check_ladder(disasm)
+  jp_add_ok = check_jp_add_internal(disasm)
+  exit(ladder_ok && jp_add_ok ? 0 : 1)
 end
 
 main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/security/check-ct-assembly.rb
+++ b/security/check-ct-assembly.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+#
+# check-ct-assembly.rb -- assembly-invariant guard on the Montgomery ladder.
+#
+# What this enforces
+# ------------------
+# The Montgomery ladder in scalar_multiply_ct_internal (ext/secp256k1_native/
+# jacobian.c) MUST compile to a loop body whose only conditional jump is the
+# public loop counter at the bottom (`jae`/`jnb` on the decremented `i`).
+# Any additional conditional jump (je, jne, jb, ja, jz, jnz, ...) or
+# conditional move (cmov*) inside the loop body is a fail.
+#
+# Why this is load-bearing (H-2 follow-up)
+# ----------------------------------------
+# Advisory GHSA-vp2j-gqfm-r3cf (H-2) recorded a real regression where GCC
+# 15.2/-O2 reconstructed a branch inside the branchless `uint256_select`
+# helper -- pushing the shipping ladder to dudect |t| ~= 21 from clean. The
+# fix is the `ct_value_barrier_u64` opaque asm in secp256k1_native.h; the
+# assembly-invariant guard this script implements catches a regression of
+# the same shape at CI time rather than at pre-tag bare-metal dudect time.
+#
+# Pairs with:
+#   - security/check-ct-mask-guard.sh (sub-issue #34), the source-layer grep
+#     guard that catches raw `-(uint64_t)cond` mask constructions at source.
+#   - the pre-tag bare-metal dudect gate (docs/timing-verification-runbook.md),
+#     which observes statistical timing of the shipping binary.
+#
+# Scope of the check
+# ------------------
+# Symbol: scalar_multiply_ct_internal.
+# Region: the trailing backward-branching loop (its target is the loop top,
+#   its own address is the bottom).
+# Failure conditions inside that region:
+#   1. more than one conditional-jump mnemonic (j<cond>), OR
+#   2. any conditional-move mnemonic (cmov<cond>).
+#
+# The check is deliberately scoped to the ladder loop body because that is
+# the primitive whose *structural* branchlessness the CT contract depends on.
+# Adjacent guards (#34 grep, dudect gate) cover the callee `jp_add_internal`
+# where H-2's `uint256_select` calls compile.
+#
+# Platform scoping
+# ----------------
+# The parser targets GNU `objdump -dl` output for AT&T-syntax x86_64. On
+# macOS local dev objdump ships as LLVM's, which emits a different format;
+# the check auto-skips there with a clear "only runs on GNU objdump / x86_64"
+# message and exits 0. CI runs on Ubuntu -- that is the load-bearing target.
+#
+# Usage
+# -----
+#   ruby security/check-ct-assembly.rb /tmp/jacobian.o
+#
+# Exit codes
+# ----------
+#   0  pass -- or graceful skip on unsupported platform
+#   1  fail -- extra conditional jump / cmov inside the ladder loop
+#   2  usage / environment error (missing objdump, missing input file, ...)
+
+require 'open3'
+require 'shellwords'
+
+SYMBOL = 'scalar_multiply_ct_internal'
+
+# Conditional-jump mnemonic pattern. On x86-64 AT&T syntax the family is
+# `j<cond>` for cond in {e, ne, z, nz, b, be, nb, a, ae, na, nae, l, le, g,
+# ge, o, no, s, ns, p, np, pe, po, c, nc, jecxz, jrcxz}. We deliberately
+# EXCLUDE unconditional `jmp` (and `jmpq`), which is a plain goto and does
+# not depend on flags.
+COND_JUMP_MNEMONICS = %w[
+  je jne jz jnz jb jbe jnb ja jae jna jnae jc jnc jecxz jrcxz
+  jl jle jg jge jo jno js jns jp jnp jpe jpo
+].freeze
+COND_JUMP_RE = /^\s+([0-9a-f]+):\s+[0-9a-f ]+\t(#{COND_JUMP_MNEMONICS.join('|')})[ql]?\s+([0-9a-f]+)/.freeze
+
+# Conditional-move family: cmove/cmovne/cmovz/cmovnz/cmovb/... -- everything
+# beginning `cmov` in the mnemonic column.
+CMOV_RE = /^\s+([0-9a-f]+):\s+[0-9a-f ]+\t(cmov\w*)\b/.freeze
+
+# Objdump line address pattern (mnemonic-agnostic).
+ADDR_RE = /^\s+([0-9a-f]+):\s+[0-9a-f]/.freeze
+
+def die(msg, code = 2)
+  warn "check-ct-assembly: #{msg}"
+  exit code
+end
+
+def skip(msg)
+  puts "check-ct-assembly: SKIP -- #{msg}"
+  exit 0
+end
+
+def parse_hex(str)
+  str.to_i(16)
+end
+
+# Return the raw output of `objdump -dl <path>`. Aborts (exit 2) on missing
+# objdump, LLVM objdump (macOS default), or objdump failure.
+def objdump_disassembly(path)
+  objdump = ENV.fetch('OBJDUMP', 'objdump')
+  version_out, status = Open3.capture2e(objdump, '--version')
+  die("`#{objdump}` failed to report a version -- is it on PATH?") unless status.success?
+  unless version_out.match?(/GNU objdump|Binutils/)
+    skip("this checker targets GNU objdump; found `#{objdump}` reporting: #{version_out.lines.first&.strip}")
+  end
+  out, err, status = Open3.capture3(objdump, '-dl', path)
+  die("`objdump -dl #{Shellwords.escape(path)}` failed: #{err.strip}") unless status.success?
+  out
+end
+
+# Slice out the lines belonging to `symbol` from objdump output. The block
+# starts at the `<symbol>:` header and ends just before the next `<label>:`
+# header at column zero (or end of file).
+def symbol_body(disasm, symbol)
+  lines = disasm.lines
+  header_re = /^[0-9a-f]+\s+<#{Regexp.escape(symbol)}>:$/
+  next_symbol_re = /^[0-9a-f]+\s+<[^>]+>:$/
+  start_idx = lines.index { |l| l =~ header_re }
+  return nil if start_idx.nil?
+
+  tail = lines[(start_idx + 1)..]
+  offset = tail.index { |l| l =~ next_symbol_re }
+  end_idx = offset.nil? ? lines.size : start_idx + 1 + offset
+  lines[(start_idx + 1)...end_idx]
+end
+
+# All conditional-jump instructions inside body_lines, as [addr, mnemonic,
+# target_addr] triples. Addresses are ints.
+def collect_cond_jumps(body_lines)
+  body_lines.each_with_object([]) do |line, acc|
+    m = line.match(COND_JUMP_RE)
+    acc << [parse_hex(m[1]), m[2], parse_hex(m[3])] if m
+  end
+end
+
+# All conditional-move instructions inside body_lines, as [addr, mnemonic]
+# pairs. Addresses are ints.
+def collect_cmovs(body_lines)
+  body_lines.each_with_object([]) do |line, acc|
+    m = line.match(CMOV_RE)
+    acc << [parse_hex(m[1]), m[2]] if m
+  end
+end
+
+# Instruction address range of a symbol body: [first_insn_addr, last_insn_addr].
+def symbol_address_range(body_lines)
+  addrs = body_lines.filter_map { |l| l.match(ADDR_RE) && parse_hex(Regexp.last_match(1)) }
+  addrs.empty? ? nil : [addrs.first, addrs.last]
+end
+
+# Identify the ladder loop closure: the trailing backward conditional jump
+# whose target lies within the symbol's address range. There should be
+# exactly one such jump in a clean build -- that is the invariant we assert.
+# Returns [loop_top_addr, loop_bottom_addr] (inclusive on both ends), or
+# nil if the symbol has no backward conditional jump (unexpected).
+def find_loop_range(body_lines, cond_jumps)
+  range = symbol_address_range(body_lines)
+  return nil if range.nil?
+
+  sym_lo, sym_hi = range
+  backwards = cond_jumps.select do |addr, _mnem, target|
+    target.between?(sym_lo, addr - 1) && addr <= sym_hi
+  end
+  return nil if backwards.empty?
+
+  bottom = backwards.max_by { |addr, _, _| addr }
+  [bottom[2], bottom[0]] # [loop_top_addr, loop_bottom_addr]
+end
+
+# Filter jumps/cmovs to those whose instruction address is inside
+# [top_addr, bottom_addr] inclusive.
+def in_range(items, top_addr, bottom_addr)
+  items.select { |addr, *| addr.between?(top_addr, bottom_addr) }
+end
+
+def loop_snippet(body_lines, top_addr, bottom_addr)
+  body_lines.select do |l|
+    m = l.match(ADDR_RE)
+    m && parse_hex(m[1]).between?(top_addr, bottom_addr)
+  end
+end
+
+# Report offences as an array of human-readable lines.
+def report_offences(loop_jumps, loop_cmovs)
+  problems = []
+  if loop_jumps.size != 1
+    problems << "expected exactly 1 conditional jump in ladder loop body, found #{loop_jumps.size}:"
+    loop_jumps.each do |addr, mnem, target|
+      problems << "    #{format('%#x', addr)}: #{mnem} -> #{format('%#x', target)}"
+    end
+  end
+  unless loop_cmovs.empty?
+    problems << "expected no conditional moves in ladder loop body, found #{loop_cmovs.size}:"
+    loop_cmovs.each do |addr, mnem|
+      problems << "    #{format('%#x', addr)}: #{mnem}"
+    end
+  end
+  problems
+end
+
+def report_pass(top_addr, bottom_addr, loop_jumps)
+  lo = format('%#x', top_addr)
+  hi = format('%#x', bottom_addr)
+  addr, mnem, = loop_jumps.first
+  puts "check-ct-assembly: PASS -- #{SYMBOL} loop body [#{lo}..#{hi}] " \
+       "contains exactly 1 conditional jump (#{format('%#x', addr)}: #{mnem}) and 0 cmov."
+end
+
+def report_fail(problems, body_lines, top_addr, bottom_addr)
+  warn 'check-ct-assembly: FAIL'
+  problems.each { |p| warn "  #{p}" }
+  warn '', 'Loop body disassembly:'
+  loop_snippet(body_lines, top_addr, bottom_addr).each { |l| warn "  #{l.chomp}" }
+  warn ''
+  warn 'This is the H-2 regression shape (GHSA-vp2j-gqfm-r3cf).'
+  warn 'Inspect ext/secp256k1_native/jacobian.c and ext/secp256k1_native/secp256k1_native.h;'
+  warn 'ensure `ct_value_barrier_u64` still applies inside `ct_mask_u64` and that no'
+  warn 'new helper in the ladder path constructs a mask outside `ct_mask_u64`.'
+end
+
+def check_host_arch!
+  host = RbConfig::CONFIG['host_cpu'] || RUBY_PLATFORM
+  return if host.include?('x86_64') || host.include?('amd64')
+
+  skip("host CPU `#{host}` is not x86_64; this check targets GCC x86_64 codegen")
+end
+
+def main(argv)
+  input = argv[0] || '/tmp/jacobian.o'
+  die("input object file `#{input}` not found") unless File.file?(input)
+  check_host_arch!
+
+  disasm = objdump_disassembly(input)
+  body = symbol_body(disasm, SYMBOL)
+  die("symbol `#{SYMBOL}` not found in `#{input}` (was it compiled from jacobian.c?)") if body.nil?
+
+  cond_jumps = collect_cond_jumps(body)
+  cmovs = collect_cmovs(body)
+  range = find_loop_range(body, cond_jumps)
+  if range.nil?
+    die("could not locate ladder loop in `#{SYMBOL}` -- no backward conditional jump found. " \
+        'Codegen may have changed shape (unrolled?). Inspect objdump -dl output manually.')
+  end
+
+  top_addr, bottom_addr = range
+  loop_jumps = in_range(cond_jumps, top_addr, bottom_addr)
+  loop_cmovs = in_range(cmovs, top_addr, bottom_addr)
+  problems = report_offences(loop_jumps, loop_cmovs)
+
+  if problems.empty?
+    report_pass(top_addr, bottom_addr, loop_jumps)
+    exit 0
+  end
+
+  report_fail(problems, body, top_addr, bottom_addr)
+  exit 1
+end
+
+main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/security/check-ct-assembly.rb
+++ b/security/check-ct-assembly.rb
@@ -114,7 +114,11 @@ end
 # objdump, LLVM objdump (macOS default), or objdump failure.
 def objdump_disassembly(path)
   objdump = ENV.fetch('OBJDUMP', 'objdump')
-  version_out, status = Open3.capture2e(objdump, '--version')
+  begin
+    version_out, status = Open3.capture2e(objdump, '--version')
+  rescue Errno::ENOENT
+    die("`#{objdump}` not found on PATH -- install binutils or set OBJDUMP to a GNU objdump.")
+  end
   die("`#{objdump}` failed to report a version -- is it on PATH?") unless status.success?
   unless version_out.match?(/GNU objdump|Binutils/)
     skip("this checker targets GNU objdump; found `#{objdump}` reporting: #{version_out.lines.first&.strip}")

--- a/security/check-ct-assembly.rb
+++ b/security/check-ct-assembly.rb
@@ -72,6 +72,7 @@
 #   2  usage / environment error (missing objdump, missing input file, ...)
 
 require 'open3'
+require 'rbconfig'
 require 'shellwords'
 
 LADDER_SYMBOL = 'scalar_multiply_ct_internal'
@@ -286,9 +287,9 @@ def check_host_arch!
   skip("host CPU `#{host}` is not x86_64; this check targets GCC x86_64 codegen")
 end
 
-def check_ladder(disasm)
+def check_ladder(disasm, input_path)
   body = symbol_body(disasm, LADDER_SYMBOL)
-  die("symbol `#{LADDER_SYMBOL}` not found -- was #{ENV['ARGV0'] || 'the object file'} compiled from jacobian.c?") if body.nil?
+  die("symbol `#{LADDER_SYMBOL}` not found in `#{input_path}` -- was it compiled from jacobian.c?") if body.nil?
 
   cond_jumps = collect_cond_jumps(body)
   cmovs = collect_cmovs(body)
@@ -318,7 +319,7 @@ def main(argv)
   check_host_arch!
 
   disasm = objdump_disassembly(input)
-  ladder_ok = check_ladder(disasm)
+  ladder_ok = check_ladder(disasm, input)
   jp_add_ok = check_jp_add_internal(disasm)
   exit(ladder_ok && jp_add_ok ? 0 : 1)
 end

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -57,11 +57,26 @@ fi
 # `(uintNN_t)` cast, and its argument `(`. Both `uint32_t` and `uint64_t` are
 # caught — narrower widths compose identically as latent branches.
 #
-# `|| true` because grep exits 1 when no lines match, which is expected on a
-# clean tree; `set -e` would otherwise abort here.
-violations=$(grep -rnE -- \
+# The primary recursive grep is run separately so we can distinguish its exit
+# codes precisely: 0 = matches, 1 = clean tree (fine), ≥2 = real error
+# (unreadable file, invalid regex, ...). A blanket `|| true` on the whole
+# pipeline would mask exit-2 as "no violations" and silently defeat the
+# guard. The subsequent filter greps operate on captured text so cannot fail
+# from I/O, and `|| true` there is safe.
+if raw_matches=$(grep -rnE -- \
         '-[[:space:]]*\([[:space:]]*uint(32|64)_t[[:space:]]*\)[[:space:]]*\(' \
-        "$SEARCH_DIR" \
+        "$SEARCH_DIR"); then
+    :  # exit 0 — matches; will filter below
+else
+    grep_status=$?
+    if [ "$grep_status" -gt 1 ]; then
+        echo "ERROR: initial grep failed with status $grep_status (unreadable file / invalid regex?)" >&2
+        exit 2
+    fi
+    raw_matches=""  # exit 1 = no matches on a clean tree
+fi
+
+violations=$(printf '%s' "$raw_matches" \
     | grep -vE '^[^:]+:[0-9]+:[[:space:]]*\*' \
     | grep -vE '(^|[^A-Za-z0-9_])ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)[[:space:]]*\(' \
     || true)

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -47,11 +47,16 @@ fi
 # Grep every occurrence of the mask-construction shape, then filter out:
 #   1. Comment lines (docstring prose) — lines whose first non-whitespace char
 #      after the "file:line:" prefix is `*`.
-#   2. Lines where the pattern is passed directly into `ct_value_barrier_u64(`
-#      with a `uint64_t` width — the one legitimate site (inside `ct_mask_u64`).
-#      Word-boundary anchored on the LHS so `my_ct_value_barrier_u64(` etc.
-#      cannot bypass. This is a semantic filter (not a line-range filter) so it
-#      survives reordering of secp256k1_native.h.
+#   2. Lines in `ext/secp256k1_native/secp256k1_native.h` where the pattern is
+#      passed directly into `ct_value_barrier_u64(...)` with a `uint64_t`
+#      width. This is the ONE legitimate site — the `ct_mask_u64` definition
+#      in the header — and the exemption is file-scoped so an inline
+#      `ct_value_barrier_u64(-(uint64_t)(cond))` written *elsewhere* still
+#      trips the guard. The stated discipline is "all masks through
+#      `ct_mask_u64`", and file scoping is what enforces it. Word-boundary
+#      anchored on the LHS so `my_ct_value_barrier_u64(` etc. cannot bypass.
+#      Prefer this over line-range anchoring so reordering within the header
+#      does not break the exemption.
 #
 # The search pattern tolerates whitespace between the leading `-` and the
 # `(uintNN_t)` cast, and does not require the cast operand to be
@@ -81,7 +86,7 @@ fi
 
 violations=$(printf '%s' "$raw_matches" \
     | grep -vE '^[^:]+:[0-9]+:[[:space:]]*\*' \
-    | grep -vE '(^|[^A-Za-z0-9_])ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)' \
+    | grep -vE '^ext/secp256k1_native/secp256k1_native\.h:[0-9]+:.*[^A-Za-z0-9_]ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)' \
     || true)
 
 if [ -n "$violations" ]; then

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -53,9 +53,12 @@ fi
 #      cannot bypass. This is a semantic filter (not a line-range filter) so it
 #      survives reordering of secp256k1_native.h.
 #
-# The search pattern tolerates whitespace between the leading `-`, the
-# `(uintNN_t)` cast, and its argument `(`. Both `uint32_t` and `uint64_t` are
-# caught — narrower widths compose identically as latent branches.
+# The search pattern tolerates whitespace between the leading `-` and the
+# `(uintNN_t)` cast, and does not require the cast operand to be
+# parenthesised — `-(uint64_t)cond` and `-(uint64_t)(cond)` are both
+# structurally equivalent latent-branch shapes and both must be caught.
+# Both `uint32_t` and `uint64_t` are matched — narrower widths compose
+# identically as latent branches.
 #
 # The primary recursive grep is run separately so we can distinguish its exit
 # codes precisely: 0 = matches, 1 = clean tree (fine), ≥2 = real error
@@ -64,7 +67,7 @@ fi
 # guard. The subsequent filter greps operate on captured text so cannot fail
 # from I/O, and `|| true` there is safe.
 if raw_matches=$(grep -rnE -- \
-        '-[[:space:]]*\([[:space:]]*uint(32|64)_t[[:space:]]*\)[[:space:]]*\(' \
+        '-[[:space:]]*\([[:space:]]*uint(32|64)_t[[:space:]]*\)' \
         "$SEARCH_DIR"); then
     :  # exit 0 — matches; will filter below
 else
@@ -78,7 +81,7 @@ fi
 
 violations=$(printf '%s' "$raw_matches" \
     | grep -vE '^[^:]+:[0-9]+:[[:space:]]*\*' \
-    | grep -vE '(^|[^A-Za-z0-9_])ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)[[:space:]]*\(' \
+    | grep -vE '(^|[^A-Za-z0-9_])ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)' \
     || true)
 
 if [ -n "$violations" ]; then

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check-ct-mask-guard.sh — CI guard against raw `-(uint64_t)(cond)` mask construction.
+# check-ct-mask-guard.sh — CI guard against raw `-(uint{32,64}_t)(cond)` mask construction.
 #
 # Background:
 #   PR #32 introduced `ct_mask_u64()` to wrap a value barrier around every

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -28,7 +28,7 @@
 #
 # Exit codes:
 #   0 — no violations (only the legitimate barrier-wrapped site matched, if any).
-#   1 — one or more raw `-(uint64_t)(...)` mask constructions found.
+#   1 — one or more raw `-(uint{32,64}_t)(...)` mask constructions found.
 #
 # Usage:
 #   bash security/check-ct-mask-guard.sh
@@ -67,7 +67,7 @@ violations=$(grep -rnE -- \
     || true)
 
 if [ -n "$violations" ]; then
-    echo "ERROR: raw -(uint64_t)( mask construction found — use ct_mask_u64() instead:" >&2
+    echo "ERROR: raw -(uint{32,64}_t)( mask construction found — use ct_mask_u64() instead:" >&2
     echo "$violations" >&2
     exit 1
 fi

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# check-ct-mask-guard.sh — CI guard against raw `-(uint64_t)(cond)` mask construction.
+#
+# Background:
+#   PR #32 introduced `ct_mask_u64()` to wrap a value barrier around every
+#   constant-time select mask, closing the GCC-15 reconstructed-branch leak
+#   documented in advisory GHSA-vp2j-gqfm-r3cf (H-2). The helper's docstring says:
+#
+#     "All constant-time masks MUST be constructed through this helper — a raw
+#      `-(uint64_t)(cond)` is a latent branch waiting for the compiler to
+#      reconstruct it."
+#
+#   Code review alone cannot enforce that discipline. This script does.
+#
+# What it does:
+#   Scans `ext/secp256k1_native/` for the mask-construction shape `-(uint64_t)(`.
+#   The pattern is legitimate only when its result is fed directly into
+#   `ct_value_barrier_u64(...)` — i.e. inside `ct_mask_u64` itself. Every other
+#   occurrence in code is a latent CT regression. Prose in docstrings is
+#   filtered by skipping lines whose first non-whitespace character is `*`.
+#
+# Exit codes:
+#   0 — no violations (only the legitimate barrier-wrapped site matched, if any).
+#   1 — one or more raw `-(uint64_t)(...)` mask constructions found.
+#
+# Usage:
+#   bash security/check-ct-mask-guard.sh
+#
+# Run from the repository root.
+
+set -euo pipefail
+
+SEARCH_DIR="ext/secp256k1_native"
+
+if [ ! -d "$SEARCH_DIR" ]; then
+    echo "ERROR: $SEARCH_DIR not found — run from the repository root." >&2
+    exit 2
+fi
+
+# Grep every occurrence of the mask-construction shape, then filter out:
+#   1. Comment lines (docstring prose) — lines whose first non-whitespace char
+#      after the "file:line:" prefix is `*`.
+#   2. Lines where the pattern is passed directly into `ct_value_barrier_u64(` —
+#      the one legitimate site (inside `ct_mask_u64`). This is a semantic filter,
+#      not a line-range filter, so it survives reordering of secp256k1_native.h.
+#
+# `|| true` because grep exits 1 when no lines match, which is expected on a
+# clean tree; `set -e` would otherwise abort here.
+violations=$(grep -rnE -- '-\(uint64_t\)\(' "$SEARCH_DIR" \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*\*' \
+    | grep -vF 'ct_value_barrier_u64(-(uint64_t)(' \
+    || true)
+
+if [ -n "$violations" ]; then
+    echo "ERROR: raw -(uint64_t)( mask construction found — use ct_mask_u64() instead:" >&2
+    echo "$violations" >&2
+    exit 1
+fi
+
+echo "OK: no raw -(uint64_t)( mask construction outside ct_value_barrier_u64."
+exit 0

--- a/security/check-ct-mask-guard.sh
+++ b/security/check-ct-mask-guard.sh
@@ -13,11 +13,18 @@
 #   Code review alone cannot enforce that discipline. This script does.
 #
 # What it does:
-#   Scans `ext/secp256k1_native/` for the mask-construction shape `-(uint64_t)(`.
-#   The pattern is legitimate only when its result is fed directly into
+#   Scans `ext/secp256k1_native/` for the mask-construction shape
+#   `-(uint{32,64}_t)(...)`. Whitespace variants are matched
+#   (`- (uint64_t)(...)`, `-(uint64_t) (...)`, `-( uint64_t )(...)` — all
+#   compile identically) so a stylistic reformat cannot silently evade the
+#   guard. The pattern is legitimate only when its result is fed directly into
 #   `ct_value_barrier_u64(...)` — i.e. inside `ct_mask_u64` itself. Every other
 #   occurrence in code is a latent CT regression. Prose in docstrings is
 #   filtered by skipping lines whose first non-whitespace character is `*`.
+#
+#   The legitimate-site filter is anchored to a word boundary on
+#   `ct_value_barrier_u64` so a lookalike wrapper (`my_ct_value_barrier_u64`,
+#   `xct_value_barrier_u64`) cannot piggyback on the exemption.
 #
 # Exit codes:
 #   0 — no violations (only the legitimate barrier-wrapped site matched, if any).
@@ -40,15 +47,23 @@ fi
 # Grep every occurrence of the mask-construction shape, then filter out:
 #   1. Comment lines (docstring prose) — lines whose first non-whitespace char
 #      after the "file:line:" prefix is `*`.
-#   2. Lines where the pattern is passed directly into `ct_value_barrier_u64(` —
-#      the one legitimate site (inside `ct_mask_u64`). This is a semantic filter,
-#      not a line-range filter, so it survives reordering of secp256k1_native.h.
+#   2. Lines where the pattern is passed directly into `ct_value_barrier_u64(`
+#      with a `uint64_t` width — the one legitimate site (inside `ct_mask_u64`).
+#      Word-boundary anchored on the LHS so `my_ct_value_barrier_u64(` etc.
+#      cannot bypass. This is a semantic filter (not a line-range filter) so it
+#      survives reordering of secp256k1_native.h.
+#
+# The search pattern tolerates whitespace between the leading `-`, the
+# `(uintNN_t)` cast, and its argument `(`. Both `uint32_t` and `uint64_t` are
+# caught — narrower widths compose identically as latent branches.
 #
 # `|| true` because grep exits 1 when no lines match, which is expected on a
 # clean tree; `set -e` would otherwise abort here.
-violations=$(grep -rnE -- '-\(uint64_t\)\(' "$SEARCH_DIR" \
+violations=$(grep -rnE -- \
+        '-[[:space:]]*\([[:space:]]*uint(32|64)_t[[:space:]]*\)[[:space:]]*\(' \
+        "$SEARCH_DIR" \
     | grep -vE '^[^:]+:[0-9]+:[[:space:]]*\*' \
-    | grep -vF 'ct_value_barrier_u64(-(uint64_t)(' \
+    | grep -vE '(^|[^A-Za-z0-9_])ct_value_barrier_u64\([[:space:]]*-[[:space:]]*\([[:space:]]*uint64_t[[:space:]]*\)[[:space:]]*\(' \
     || true)
 
 if [ -n "$violations" ]; then
@@ -57,5 +72,5 @@ if [ -n "$violations" ]; then
     exit 1
 fi
 
-echo "OK: no raw -(uint64_t)( mask construction outside ct_value_barrier_u64."
+echo "OK: no raw -(uint{32,64}_t)( mask construction outside ct_value_barrier_u64."
 exit 0

--- a/security/run-checks.sh
+++ b/security/run-checks.sh
@@ -43,6 +43,40 @@ else
   echo "  FAIL: valgrind reported errors (re-run ./ctgrind_harness under valgrind to see them)"; rc=1
 fi
 
+echo "== CT source guard (no raw -(uintNN_t) mask constructions) =="
+if (cd .. && bash security/check-ct-mask-guard.sh) >/dev/null 2>&1; then
+  echo "  PASS: no raw -(uintNN_t) constructions outside ct_value_barrier_u64"
+else
+  echo "  FAIL: raw mask construction found (re-run: bash security/check-ct-mask-guard.sh)"; rc=1
+fi
+
+echo "== CT assembly invariant (ladder + jp_add_internal branchlessness) =="
+if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+  echo "  SKIP: only runs on Linux x86_64 (see .github/workflows/ct-assembly-invariant.yml)"
+elif ! command -v objdump >/dev/null 2>&1; then
+  echo "  SKIP: GNU objdump not present"
+elif ! command -v gcc >/dev/null 2>&1; then
+  echo "  SKIP: gcc not present"
+else
+  ruby_hdr=$(ruby -e 'puts RbConfig::CONFIG["rubyhdrdir"]' 2>/dev/null || true)
+  ruby_arch_hdr=$(ruby -e 'puts RbConfig::CONFIG["rubyarchhdrdir"]' 2>/dev/null || true)
+  jacobian_o=$(mktemp -t jacobian.o.XXXXXX)
+  if gcc -O2 -g -Wall -std=c99 -fcommon -fno-stack-protector \
+         -I ../ext/secp256k1_native \
+         -I "$ruby_hdr" -I "$ruby_arch_hdr" \
+         -c ../ext/secp256k1_native/jacobian.c \
+         -o "$jacobian_o" 2>/dev/null; then
+    if ruby check-ct-assembly.rb "$jacobian_o" >/dev/null 2>&1; then
+      echo "  PASS: ladder + jp_add_internal branchlessness invariants hold"
+    else
+      echo "  FAIL: CT assembly invariant violated (re-run: ruby security/check-ct-assembly.rb <path>)"; rc=1
+    fi
+  else
+    echo "  SKIP: compile of jacobian.c failed (Ruby headers unavailable?)"
+  fi
+  rm -f "$jacobian_o"
+fi
+
 echo
 echo "overall: $([ $rc -eq 0 ] && echo PASS || echo FAIL)"
 exit $rc


### PR DESCRIPTION
## Summary

Closes umbrella HLR #54 and its three sub-issues by adding the three structural controls the H-2 finding demanded ([GHSA-vp2j-gqfm-r3cf](https://github.com/sgbett/secp256k1-native/security/advisories/GHSA-vp2j-gqfm-r3cf)):

| Layer | Control | Sub-issue | Commit(s) |
|---|---|---|---|
| Source | Grep guard against raw `-(uint{32,64}_t)(cond)` outside `ct_value_barrier_u64` | #34 | `c4d515d` + `d1f1129` (hardened) |
| Binary | Assembly-invariant check on `scalar_multiply_ct_internal`'s loop body + `jp_add_internal`'s body | #35 | `66eb123` + `d1f1129` (extended) |
| Procedural | `docs/RELEASING.md` pre-tag checklist with bare-metal dudect as an explicit box | #36 | `7a2e846` |

Together with the pre-tag bare-metal dudect run itself (the runtime evidence), these form the four-layer control H-2 demanded: source guard → binary check → procedural gate → empirical measurement.

## Closes

- Closes #34
- Closes #35
- Closes #36
- Closes #54

## Files

- `security/check-ct-mask-guard.sh` — grep guard shell script
- `security/check-ct-assembly.rb` — Ruby objdump parser (ladder loop + `jp_add_internal` body)
- `.github/workflows/ct-source-guard.yml` — CI wrapper for the grep guard
- `.github/workflows/ct-assembly-invariant.yml` — CI wrapper for the assembly check (Ubuntu / GCC)
- `docs/RELEASING.md` — the release-gate checklist
- `docs/security.md` — cross-link to `RELEASING.md`
- `.rubocop.yml` — scoped relaxation for `security/*.rb`

## Test plan

- [x] `bash security/check-ct-mask-guard.sh` — exits 0 on clean tree
- [x] Grep guard negative tests: caught all 4 evasion classes flagged by white-hat (raw, whitespace-variant, `uint32_t`, lookalike wrapper) with clear file:line diagnostic
- [x] `ruby security/check-ct-assembly.rb` — SKIPs cleanly on arm64 macOS (host arch check)
- [x] `bundle exec rake` — 416 examples, 0 failures
- [x] `bundle exec rake docs:{build,lint,proofread}` — green
- [ ] CI on push + PR events — Ubuntu docs/main matrix + new `CT source guard` and `CT assembly invariant` workflows

## White-hat review

Ran on the initial commits and flagged three follow-ups. All three applied here in `d1f1129`:

1. **Grep whitespace + width tolerance** — `- (uint64_t)(...)`, `-(uint64_t) (...)`, `-(uint32_t)(...)` all now caught.
2. **Word-boundary the exclusion** — `my_ct_value_barrier_u64(-(uint64_t)(...))` no longer piggybacks the exemption.
3. **Extend assembly check to `jp_add_internal`** — closes the compiler-only reconstruction gap where the H-2-shape branch would have landed in non-inlined `jp_add_internal` rather than the ladder loop itself.

Verdict: `SHIP`.

## Workflow hygiene

Both new workflows follow the project convention set by PR #44/#51:

- Workflow-level `permissions: {}` (deny-all)
- Job-scoped `contents: read` on the check job
- `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (v7.0.0) and `ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601` (v1.315.0) — same SHAs as `main.yml`/`docs.yml`
- `pull_request` trigger (never `_target`)
- Path filters scoped to `ext/**`, the relevant `security/` script, and the workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
