### PR TITLE
docs: make docs/architecture.md the canonical architecture reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Default rake task runs `compile` then `spec`.
 
 ## Architecture
 
+> **Canonical reference: [docs/architecture.md](docs/architecture.md).** This section is the operational summary for editing; the deep internals (`uint256_t` representation, Integer marshalling, fast reduction, wNAF cache) live there.
+
 ### Dual-implementation pattern
 
 The core design: all curve operations are implemented in pure Ruby (`lib/secp256k1.rb`), then selectively replaced by C equivalents at load time.
@@ -92,9 +94,8 @@ The core design: all curve operations are implemented in pure Ruby (`lib/secp256
 
 - Requires C99 compiler with `__uint128_t` support (GCC/Clang on x86_64/arm64)
 - On unsupported platforms (MSVC/Windows): generates no-op Makefile, gem still installs
-- Internal representation: `uint256_t` struct of 4 x `uint64_t` limbs (little-endian)
-- Marshals Ruby Integers via `rb_integer_pack`/`rb_integer_unpack`
-- Compiled output: `lib/secp256k1_native.bundle` (macOS) or `lib/secp256k1_native.so` (Linux)
+
+Internal representation (`uint256_t` limbs), Integer marshalling, and fast reduction: see [docs/architecture.md](docs/architecture.md#internal-representation-c-extension).
 
 ### Scalar multiplication strategies
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ k = Secp256k1.scalar_inv(42)  # scalar inverse
 
 ## Architecture
 
+A high-level overview follows. For internal implementation details — the dual-implementation pattern, the full list of replaced methods, the `uint256_t` representation, and the scope table — see [docs/architecture.md](docs/architecture.md).
+
 ```
 secp256k1-native
 ├── lib/secp256k1.rb           # Pure-Ruby module: field, scalar, point ops, wNAF, Montgomery ladder
@@ -84,16 +86,9 @@ secp256k1-native
 
 ### Native C extension (optional)
 
-`Secp256k1Native` is an optional C extension that replaces hot-path field, scalar, and Jacobian point operations with fixed-width C implementations. When compiled, `secp256k1.rb` automatically delegates to the extension at load time.
+`Secp256k1Native` is an optional C extension that replaces hot-path field, scalar, and Jacobian point operations — plus the constant-time Montgomery ladder (fully branchless `cswap`) — with fixed-width C implementations. When compiled, `secp256k1.rb` automatically delegates to the extension at load time; the wNAF loop and ECDSA/Schnorr logic remain in Ruby, calling native primitives per step.
 
-The extension accelerates:
-
-- All field arithmetic (`fmul`, `fsqr`, `fadd`, `fsub`, `fneg`, `finv`, `fsqrt`, `fred`)
-- All scalar arithmetic (`scalar_mul`, `scalar_add`, `scalar_inv`, `scalar_mod`)
-- Jacobian point operations (`jp_double`, `jp_add`, `jp_neg`)
-- Montgomery ladder (`scalar_multiply_ct`) — fully branchless cswap in C
-
-The wNAF loop and ECDSA/Schnorr logic remain in Ruby, calling native primitives per step.
+See [docs/architecture.md](docs/architecture.md) for the full list of replaced methods and the dual-implementation pattern.
 
 ### Performance
 


### PR DESCRIPTION
Makes `docs/architecture.md` the single canonical architecture reference and removes the
duplicated deep internals from README and CLAUDE.md. Documentation only.

## Assessment first

Reading all four "architecture" surfaces showed it's **not** four redundant copies:

| Surface | Role | Action |
|---|---|---|
| `docs/architecture.md` | deep "what/how" (contributors/auditors) | **canonical** — no change |
| `docs/design.md` | the "why" (rationale) — distinct, cross-links architecture.md | **untouched** |
| `README §Architecture` | shallow consumer summary | pointer + trim exhaustive list |
| `CLAUDE.md §Architecture` | condensed duplicate of architecture.md | pointer + trim deep internals |

So the real overlap was CLAUDE.md ↔ architecture.md (plus README's exhaustive function
list). Reducing `design.md` to a link would have destroyed genuinely distinct content —
so it's left alone.

## What changed

- **CLAUDE.md §Architecture** — canonical-reference pointer at the top; dropped the
  `uint256_t`/marshalling/compiled-output internals (now linked to
  `architecture.md#internal-representation-c-extension`); kept the operational summary
  (dual-impl pattern + full replaced-methods list, scalar strategies, CT discipline, key
  types) inline for editing.
- **README §Architecture** — same pointer; replaced the exhaustive per-function
  accelerated list with a one-line summary + link.

Approach chosen: light-touch (pointer + trim deep dup only), so each audience keeps the
inline detail it needs.

## Out of scope / flagged

- **Test-example count drift**: README says "303 examples", CLAUDE.md "368", the advisory
  "416". That's in the Build/Testing sections (not Architecture) and needs the true count
  from a run — left for a separate follow-up rather than guessed at here.

Closes #63
