### PR TITLE
docs: correct stale test-example count (303/368 → 416)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When testing or development reveals a security issue (side-channel leakage, arit
 ```bash
 bundle install                        # Install dependencies
 bundle exec rake compile              # Compile C extension
-bundle exec rspec                     # Run full test suite (368 examples)
+bundle exec rspec                     # Run full test suite (416 examples)
 bundle exec rspec spec/secp256k1_spec.rb           # Pure-Ruby tests only
 bundle exec rspec spec/secp256k1_native_spec.rb    # C extension tests only
 bundle exec rspec spec/secp256k1_compliance_spec.rb # Wycheproof compliance

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The compiled bundle is placed at `lib/secp256k1_native.bundle` (macOS) or `lib/s
 bundle exec rspec
 ```
 
-The test suite has 303 examples covering:
+The test suite has 416 examples covering:
 
 - Wycheproof ECDSA compliance vectors
 - Field, scalar, and Jacobian compliance vectors

--- a/docs/running-checks.md
+++ b/docs/running-checks.md
@@ -77,7 +77,7 @@ macOS with no special tooling:
 ```sh
 bundle install
 bundle exec rake compile        # builds lib/secp256k1_native.bundle on macOS (.so on Linux)
-bundle exec rspec               # 368 examples
+bundle exec rspec               # 416 examples
 ```
 
 (The binstub-not-on-PATH and `-fcommon` quirks noted in the harness builds were


### PR DESCRIPTION
Corrects the stale test-example count in the current-state docs. The suite is **416
examples** (verified `bundle exec rspec --dry-run`, matching the 0.18.0 CHANGELOG/advisory);
README, CLAUDE.md, and `running-checks.md` disagreed (303 and 368).

## Changed (current-state claims)
- `README.md` — "303 examples" → "416"
- `CLAUDE.md` — "(368 examples)" → "(416 examples)"
- `docs/running-checks.md` — "# 368 examples" → "# 416"

## Deliberately left (point-in-time records — changing them would falsify history)
- `CHANGELOG.md` 0.16.0 entry "303 examples" — the count at that release
- `docs/security-review-v1.md` "368 examples" — the suite actually run under ASan/UBSan during the review
