### PR TITLE
docs: reflow hard-wrapped prose (running-checks, timing-runbook)

### DIFF
--- a/docs/running-checks.md
+++ b/docs/running-checks.md
@@ -6,10 +6,7 @@ nav_order: 1
 
 # Running the security checks (macOS / Docker)
 
-The pre-v1.0 review ([`security-review-v1.md`](security-review-v1.md)) left four
-empirical checks behind. This page is the guide to re-running them off the cloud
-— in particular from a macOS workstation. The governing distinction is
-**deterministic vs statistical**:
+The pre-v1.0 review ([`security-review-v1.md`](security-review-v1.md)) left four empirical checks behind. This page is the guide to re-running them off the cloud — in particular from a macOS workstation. The governing distinction is **deterministic vs statistical**:
 
 | Check | Kind | Reproducible off bare metal? | How to run from a Mac |
 |-------|------|------------------------------|-----------------------|
@@ -18,19 +15,11 @@ empirical checks behind. This page is the guide to re-running them off the cloud
 | ctgrind secret-poisoning | deterministic (data-flow) | yes — platform-independent | **Docker** (valgrind has no native macOS support) |
 | dudect timing | **statistical** (wall-clock) | **no — needs quiet bare metal** | not Docker — see the runbook |
 
-The first three verify *data-flow facts* (does output match the reference? does
-a poisoned value reach a branch?), so a VM or container reproduces the cloud
-results exactly. dudect measures *cycle counts*; virtualization changes the
-counter and the noise floor and invalidates the t-test — so it is the one check
-Docker cannot stand in for. See
-[`timing-verification-runbook.md`](timing-verification-runbook.md) and issue #25.
+The first three verify *data-flow facts* (does output match the reference? does a poisoned value reach a branch?), so a VM or container reproduces the cloud results exactly. dudect measures *cycle counts*; virtualization changes the counter and the noise floor and invalidates the t-test — so it is the one check Docker cannot stand in for. See [`timing-verification-runbook.md`](timing-verification-runbook.md) and issue #25.
 
 ## Option A — Docker (recommended; covers all three deterministic gates)
 
-Docker is the cleanest path from macOS because it runs the three deterministic
-gates exactly as the review did, **including ctgrind** — valgrind does not run
-natively on macOS, but it does support arm64 Linux, so a native container runs
-it un-emulated.
+Docker is the cleanest path from macOS because it runs the three deterministic gates exactly as the review did, **including ctgrind** — valgrind does not run natively on macOS, but it does support arm64 Linux, so a native container runs it un-emulated.
 
 ```sh
 # from the repo root
@@ -43,21 +32,13 @@ docker build -f security/Dockerfile -t secp-review .
 docker run --rm secp-review
 ```
 
-The container runs `security/run-checks.sh`, which builds and runs all three and
-prints PASS/FAIL. On the reviewed tree expect: differential **PASS**, ASan/UBSan
-**PASS**, ctgrind **KNOWN** (it reports the I-11 `scalar_reduce_limbs` branches
-until #21 lands — *not* a failure). Crank coverage with `-e ITERS=2000000`.
+The container runs `security/run-checks.sh`, which builds and runs all three and prints PASS/FAIL. On the reviewed tree expect: differential **PASS**, ASan/UBSan **PASS**, ctgrind **KNOWN** (it reports the I-11 `scalar_reduce_limbs` branches until #21 lands — *not* a failure). Crank coverage with `-e ITERS=2000000`.
 
-> **Apple Silicon caveat:** run the container **native arm64**, not
-> `linux/amd64` under qemu. valgrind works on arm64 Linux but not when it is
-> itself being emulated by qemu — an amd64 image on an M-series Mac will make the
-> ctgrind gate hang or misreport. The differential and ASan gates work either
-> way (amd64-under-qemu is just slower).
+> **Apple Silicon caveat:** run the container **native arm64**, not `linux/amd64` under qemu. valgrind works on arm64 Linux but not when it is itself being emulated by qemu — an amd64 image on an M-series Mac will make the ctgrind gate hang or misreport. The differential and ASan gates work either way (amd64-under-qemu is just slower).
 
 ## Option B — Native macOS (differential + ASan only)
 
-The differential fuzzer and the ASan/UBSan sweep build with clang and run
-natively. ctgrind does not (no native valgrind) — use Docker for that gate.
+The differential fuzzer and the ASan/UBSan sweep build with clang and run natively. ctgrind does not (no native valgrind) — use Docker for that gate.
 
 ```sh
 cd security
@@ -66,13 +47,11 @@ make asan    && UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./asan_sweep
 # make ctgrind / valgrind  -> not available natively on macOS; use Docker
 ```
 
-The `security/Makefile` uses `cc` (clang on macOS) and `-fcommon`, both fine on
-Apple Silicon; `__uint128_t` is supported by clang on arm64.
+The `security/Makefile` uses `cc` (clang on macOS) and `-fcommon`, both fine on Apple Silicon; `__uint128_t` is supported by clang on arm64.
 
 ## The Ruby test suite
 
-Separate from the standalone harnesses, the gem's own suite runs natively on
-macOS with no special tooling:
+Separate from the standalone harnesses, the gem's own suite runs natively on macOS with no special tooling:
 
 ```sh
 bundle install
@@ -80,16 +59,8 @@ bundle exec rake compile        # builds lib/secp256k1_native.bundle on macOS (.
 bundle exec rspec               # 416 examples
 ```
 
-(The binstub-not-on-PATH and `-fcommon` quirks noted in the harness builds were
-specific to the review's CI container; a normal rbenv + bundler setup on macOS
-does not need them.)
+(The binstub-not-on-PATH and `-fcommon` quirks noted in the harness builds were specific to the review's CI container; a normal rbenv + bundler setup on macOS does not need them.)
 
 ## dudect timing (issue #25) — bare metal only
 
-Do **not** run this in Docker or a VM. Follow
-[`timing-verification-runbook.md`](timing-verification-runbook.md) on a quiet,
-frequency-pinned physical machine, and record the |t| figures with hardware
-provenance. An Apple Silicon Mac can serve as the quiet machine, but the runbook's
-knobs (`intel_pstate`, `cpupower`, `isolcpus`) are Linux/x86-specific — on macOS
-quiesce the machine, run on a performance core, and treat the numbers with the
-P/E-core caveat; a dedicated quiet Linux box remains the gold standard.
+Do **not** run this in Docker or a VM. Follow [`timing-verification-runbook.md`](timing-verification-runbook.md) on a quiet, frequency-pinned physical machine, and record the |t| figures with hardware provenance. An Apple Silicon Mac can serve as the quiet machine, but the runbook's knobs (`intel_pstate`, `cpupower`, `isolcpus`) are Linux/x86-specific — on macOS quiesce the machine, run on a performance core, and treat the numbers with the P/E-core caveat; a dedicated quiet Linux box remains the gold standard.

--- a/docs/timing-verification-runbook.md
+++ b/docs/timing-verification-runbook.md
@@ -6,31 +6,19 @@ nav_order: 2
 
 # Timing verification runbook (bare-metal)
 
-This is a checklist for re-running the **statistical** constant-time verification
-(`dudect` / Welch's t-test) on a quiet, isolated machine. It exists because the
-cloud/CI environment where the automated security review runs is a shared VM, and
-shared VMs are the wrong place to make a *timing* claim.
+This is a checklist for re-running the **statistical** constant-time verification (`dudect` / Welch's t-test) on a quiet, isolated machine. It exists because the cloud/CI environment where the automated security review runs is a shared VM, and shared VMs are the wrong place to make a *timing* claim.
 
 ## Why this can't be trusted in the cloud
 
-The `ctgrind` / valgrind secret-poisoning check (run in CI) is **deterministic**:
-it flags any machine instruction that branches or addresses memory based on a
-secret, regardless of how noisy the host is. That result is trustworthy anywhere.
+The `ctgrind` / valgrind secret-poisoning check (run in CI) is **deterministic**: it flags any machine instruction that branches or addresses memory based on a secret, regardless of how noisy the host is. That result is trustworthy anywhere.
 
-The `dudect` check is **statistical**: it runs the operation tens of thousands of
-times on two input classes and asks whether the timing distributions differ
-(|t| < 4.5 ⇒ no detectable leak). On a shared VM, three things corrupt that
-measurement:
+The `dudect` check is **statistical**: it runs the operation tens of thousands of times on two input classes and asks whether the timing distributions differ (|t| < 4.5 ⇒ no detectable leak). On a shared VM, three things corrupt that measurement:
 
-- **Neighbour noise** — other tenants' load perturbs your timings unpredictably,
-  inflating variance. This can *hide* a real leak (false pass) or *invent* one
-  (false fail).
-- **Frequency scaling / turbo** — the CPU changing clock mid-run adds timing
-  variation uncorrelated with the secret, again polluting the t-statistic.
+- **Neighbour noise** — other tenants' load perturbs your timings unpredictably, inflating variance. This can *hide* a real leak (false pass) or *invent* one (false fail).
+- **Frequency scaling / turbo** — the CPU changing clock mid-run adds timing variation uncorrelated with the secret, again polluting the t-statistic.
 - **No `rdtsc`/PMU stability guarantees** — the cycle counter may be virtualised.
 
-So: treat the cloud `dudect` numbers as a smoke test, and treat the bare-metal
-run below as the number you actually cite for v1.
+So: treat the cloud `dudect` numbers as a smoke test, and treat the bare-metal run below as the number you actually cite for v1.
 
 ## What you need
 
@@ -66,8 +54,7 @@ cd timing
 #  in docs/security-review-v1.md.)
 ```
 
-If this fails anywhere, stop — a deterministic secret-dependent branch is a real
-leak and no amount of statistical massaging changes that. Fix it first.
+If this fails anywhere, stop — a deterministic secret-dependent branch is a real leak and no amount of statistical massaging changes that. Fix it first.
 
 ### 3. Run dudect, pinned, for a long time
 
@@ -79,31 +66,18 @@ make clean && make
 taskset -c 3 ./timing_harness
 ```
 
-Record the |t| for each measured op (`fred`, `fsub`, `fneg`, `fadd`,
-`scalar_multiply_ct`, and any others the harness covers).
+Record the |t| for each measured op (`fred`, `fsub`, `fneg`, `fadd`, `scalar_multiply_ct`, and any others the harness covers).
 
 ### 4. Interpret
 
-- **|t| < 4.5** across a long run ⇒ no timing leak detectable at this sample size.
-  This is the pass condition the project already uses.
-- **|t| ≥ 4.5** ⇒ investigate. First rule out measurement artefacts: re-run,
-  confirm the machine is quiet, confirm turbo is off. A *persistent*,
-  reproducible high |t| that survives a quiet bare-metal run is a real finding —
-  triage it per the "Security findings" process in `CLAUDE.md`.
-- Note the known marginal artefact already documented in `risks.md`
-  (`jp_add_internal` isolation, |t| ≈ 7.5 from operand-value microarchitectural
-  variation, not a branch) — don't re-flag that as new.
+- **|t| < 4.5** across a long run ⇒ no timing leak detectable at this sample size. This is the pass condition the project already uses.
+- **|t| ≥ 4.5** ⇒ investigate. First rule out measurement artefacts: re-run, confirm the machine is quiet, confirm turbo is off. A *persistent*, reproducible high |t| that survives a quiet bare-metal run is a real finding — triage it per the "Security findings" process in `CLAUDE.md`.
+- Note the known marginal artefact already documented in `risks.md` (`jp_add_internal` isolation, |t| ≈ 7.5 from operand-value microarchitectural variation, not a branch) — don't re-flag that as new.
 
 ### 5. Record it
 
-Capture the machine (CPU model, microcode, kernel), the run duration, the sample
-count, and the final |t| per op. Drop those numbers into `risks.md` /
-`security-review-v1.md` so the v1 timing claim is backed by a reproducible,
-quiet-hardware measurement rather than a cloud smoke test.
+Capture the machine (CPU model, microcode, kernel), the run duration, the sample count, and the final |t| per op. Drop those numbers into `risks.md` / `security-review-v1.md` so the v1 timing claim is backed by a reproducible, quiet-hardware measurement rather than a cloud smoke test.
 
 ## One-line summary
 
-The cloud run tells you **whether the code has a secret-dependent branch**
-(deterministic, trustworthy anywhere). The bare-metal run tells you **whether the
-compiled timing is actually flat** (statistical, only trustworthy on quiet
-hardware). v1 wants both, and only step 3–5 here need your workstation.
+The cloud run tells you **whether the code has a secret-dependent branch** (deterministic, trustworthy anywhere). The bare-metal run tells you **whether the compiled timing is actually flat** (statistical, only trustworthy on quiet hardware). v1 wants both, and only step 3–5 here need your workstation.


### PR DESCRIPTION
Two `docs/` files had adopted 80-char hard wrapping while the rest of `docs/` runs one-line-per-paragraph. Unwraps them to match.

- Prose paragraphs, list items (continuation lines folded in), and the one blockquote → single logical lines.
- **Untouched (byte-identical):** tables, fenced code blocks, headings, YAML frontmatter.
- **Verified:** marker/whitespace-normalised content is identical before/after — only line wrapping changed (no words added, dropped, or reordered).

Plan files were deliberately left hard-wrapped.