### PR TITLE
feat(nix): reproducible timing-verification toolchain — devShell (Phase 1 of #61)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
 
   # Pinned via flake.lock. The locked nixpkgs revision IS the gate's
   # "known-good compiler" record: bumping this input is the deliberate trigger
-  # to re-run the bare-metal dudect gate (see plans/reference-machine-nix.md and
+  # to re-run the bare-metal dudect gate (see plans/61-reference-machine-nix.md and
   # docs/security.md#empirical-timing-verification).
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
           binutils # objdump, for the disassembly branch-check
           valgrind # ctgrind deterministic constant-time gate
           util-linux # taskset / chrt for pinned dudect runs
+          pkg-config # lets native gems (psych) locate libyaml
+          libyaml # psych's C dependency — pulled in via yard-markdown -> rdoc
         ];
 
         shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description =
+    "secp256k1-native — reproducible timing-verification toolchain & reference machine";
+
+  # Pinned via flake.lock. The locked nixpkgs revision IS the gate's
+  # "known-good compiler" record: bumping this input is the deliberate trigger
+  # to re-run the bare-metal dudect gate (see plans/reference-machine-nix.md and
+  # docs/security.md#empirical-timing-verification).
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      # Reproducible toolchain — `nix develop`.
+      #
+      # This shell both COMPILES and MEASURES the C extension, so the gem's
+      # timing-sensitive codegen is reproducible. Important nuance: the
+      # extension is built by Ruby's configured CC (RbConfig CC), printed by the
+      # shellHook — pinning *that* compiler is what the gate certifies, not the
+      # bare `gcc` on PATH. (Refinement for the real box: pin the CC explicitly,
+      # e.g. to gcc15 to match where issue #25 was found.)
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          ruby_3_3
+          bundler
+          gcc # compiler under test
+          gnumake # builds the timing/ and security/ harnesses
+          binutils # objdump, for the disassembly branch-check
+          valgrind # ctgrind deterministic constant-time gate
+          util-linux # taskset / chrt for pinned dudect runs
+        ];
+
+        shellHook = ''
+          # Keep gem installs local and out of the git tree.
+          export BUNDLE_PATH="$PWD/.bundle"
+          echo "secp256k1-native timing toolchain (flake-pinned):"
+          echo "  gcc      : $(gcc --version | head -1)"
+          echo "  ruby     : $(ruby --version)"
+          echo "  ext CC   : $(ruby -rrbconfig -e 'print RbConfig::CONFIG["CC"]')   <- compiles the C extension"
+          echo "  valgrind : $(valgrind --version)"
+        '';
+      };
+    };
+}


### PR DESCRIPTION
## Summary

**Phase 1 of #61** — lands the reproducible timing-verification toolchain as a Nix flake `devShell`. This is the foundation for the NixOS sweep-ISO reference machine ([`plans/61-reference-machine-nix.md`](https://github.com/sgbett/secp256k1-native/blob/master/plans/61-reference-machine-nix.md)); it is **additive** (a new `flake.nix`/`flake.lock`) with **zero impact** on `gem install` / `bundle`.

The `devShell` pins the toolchain that both **compiles and measures** the C extension, so the gem's timing-sensitive codegen is reproducible. The locked `nixpkgs` revision in `flake.lock` **is** the gate's "known-good compiler" record — bumping it is the deliberate trigger to re-run the bare-metal dudect gate.

Pinned (`nixos-25.05` @ `ac62194`): GCC 14.3.0, Ruby 3.3.9, valgrind 3.24.0, binutils, util-linux, plus `libyaml`/`pkg-config`.

## Commits

- `feat(nix)`: the flake `devShell` (originally `c6bd59a`, carried forward).
- `fix(nix)`: point the flake comment at the renamed plan path (`plans/61-reference-machine-nix.md`) — clears the #61 carried-forward TODO.
- `fix(nix)`: add `libyaml` + `pkg-config` so `bundle install` can build psych's native extension (psych ← rdoc ← yard-markdown), which otherwise fails with `yaml.h not found`.

## Test plan

Validated in an **emulated x86_64** `nixos/nix` container (aarch64 host, `--platform linux/amd64`) — the Docker build path from the plan's Build & test logistics (nix-in-linux, no KVM):

- `nix develop` → toolchain resolves: `gcc 14.3.0`, `ruby 3.3.9 [x86_64-linux]`, `valgrind 3.24.0`.
- `bundle install` → 34 gems, clean.
- `rake compile` → `secp256k1_native.so` (**ELF 64-bit x86-64**).
- `bundle exec rspec` → **416 examples, 0 failures**.
- `ctgrind` (valgrind secret-poisoning) → **CLEAN (exit 0)**.

Note: nix requires `sandbox = false` + `filter-syscalls = false` under nested/emulated Docker (seccomp BPF can't load) — a runtime nix.conf setting, not baked into the flake.

## Scope

Phase 1 only: `devShell`. The quiet-machine NixOS module, the vanilla-`gcc` codegen proof, the unattended gate, the sweep-ISO, and the docs follow in later phases on a separate branch. Does **not** close #61 (multi-phase HLR).

Part of #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
