### PR TITLE
feat(nix): iteration diagnostics + interactive debug ISO (Closes #70)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,18 @@
       # coreutils/sed/grep/awk are the gate's text plumbing (a minimal ISO PATH
       # otherwise lacks them).
       gateTools = [ gateGems pkgs.ruby_3_3 pkgs.gnumake pkgs.binutils pkgs.valgrind pkgs.util-linux pkgs.bash pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.gawk ] ++ gccSet;
+
+      # The ctgrind harness includes <valgrind/memcheck.h>, which nixpkgs ships in
+      # valgrind's `dev` output — NOT its `out` (bin/lib only). In `nix develop`
+      # the header is found automatically because valgrind is a buildInput (the
+      # cc-wrapper injects its include via NIX_CFLAGS_COMPILE); outside a devShell
+      # (the ISO service, `nix run .#timing-gate`, the debug MOTD) nothing does, so
+      # the ctgrind build fails "memcheck.h: No such file or directory". Point the
+      # nix gcc wrapper at the dev include explicitly. -isystem is codegen-neutral
+      # (a header search path only; jacobian.c never includes it), so this does not
+      # perturb the vanilla CT build the gate certifies. Referencing the store path
+      # here also pulls valgrind.dev into the ISO closure so the header is present.
+      valgrindCFlags = "-isystem ${pkgs.lib.getDev pkgs.valgrind}/include";
     in
     {
       # Reproducible toolchain — `nix develop`.
@@ -85,6 +97,10 @@
           # GATE_SOURCE_REV from the flake instead).
           export PATH=${pkgs.lib.makeBinPath (gateTools ++ [ pkgs.git ])}:$PATH
           export GATE_RUBY_EXEC=""
+          # valgrind's memcheck.h lives in its `dev` output (see valgrindCFlags);
+          # make the nix gcc wrapper find it so the ctgrind step builds outside a
+          # devShell too.
+          export NIX_CFLAGS_COMPILE="${valgrindCFlags} ''${NIX_CFLAGS_COMPILE:-}"
           exec ${pkgs.bash}/bin/bash nix/gate.sh "$@"
         '');
       };
@@ -94,7 +110,7 @@
         inherit system;
         specialArgs = {
           refSource = self; # the flake source, baked into the image
-          inherit gateGems gccSet gateTools;
+          inherit gateGems gccSet gateTools valgrindCFlags;
         };
         modules = [
           ./nix/reference-machine.nix

--- a/nix/debug-ssh-authorized-keys
+++ b/nix/debug-ssh-authorized-keys
@@ -2,9 +2,7 @@
 # reference-machine ISO (see nix/iso.nix → specialisation.debug).
 #
 # Add one public key per line, then rebuild the ISO (`nix build .#iso`) and
-# re-flash the stick. Until a key is present here, key-based root SSH is
-# effectively disabled (secure default) — use the autologin root console on the
-# box (grab the DHCP IP with `ip a`, or `passwd` to set a temporary password).
-#
-# Example:
-#   ssh-ed25519 AAAAC3Nza... simon@macbook
+# re-flash the stick. Key-only root SSH (PermitRootLogin=prohibit-password);
+# with no key here it's effectively disabled — use the autologin root console.
+
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLI1nqsUQRLrACY32nEiHhpYF1bF94qwabbNoqF4XSzd0BG3f+be6wRNOIyEfT3IDGELLekUC1lscH4fIQYq2JUgCjXnS0wTg1U9dOKaGONlXH4dsS5x0zFjEzM+DCk9pqynbDW0FUhJ2ilLkhmeIfPzN0eYMLEBHCMK2GMxwgiMEYtncUcLSDhYD7xPVm2N+zmjvUrU36C9ogGGC6T6fQm2EUlNGuTQWIIIsif2LaFWqwc971a+9cwtmkDh9va7IjpsXr6z87z3vDmnrSVESyr6RGDr/ytbXzl1rzDJ3ni0xmRBPAgs3x0rpvqiMhnq1s2KkW9A0qhasCYDC9UBIAeshDQoLMuB+iJG3MhsEycg+6NLj5fTJtOw+coDfYLMq5PVD+tVlHjh/w4vr/WYQlJOY2D619mKvmRvrF95fZXcOck0+U5I5up0qlWx8FY1U1xQIeFlZivfYHTTadaDTEN5FPopMCbrP2f3kqdZB4bdl6zHBkOJwHsBt5K6FK/MRj/TZx/HMh5paiPqn9vbb8Krh3XzexIwXRSh7M2FCdi+FF4fcFP3AoaW2abIDdM7vMaxAsHEMGcH1FpMY54o0OKiP8LEhYBUSB0DnsSz3eZDLqZZqTs0XPQymIpoEowiC3QRwMNvNJdiD+Lc1uwUsneJRewkoS7vEzxnLyzE/F+Q== simon@macbook

--- a/nix/debug-ssh-authorized-keys
+++ b/nix/debug-ssh-authorized-keys
@@ -6,9 +6,10 @@
 # (do NOT commit them) and build: `nix build .#iso` reads the working tree, so a
 # dirty-tree build bakes your key without it ever entering git history.
 #
-# Key-only root SSH (PermitRootLogin=prohibit-password); with no key here, key
-# auth is effectively off — use the autologin root console (grab the DHCP IP
-# with `ip a`, or `passwd`).
+# Key-only root SSH (PermitRootLogin=prohibit-password). With no key baked, SSH
+# is effectively closed — password SSH is OFF, so `passwd` won't open it. Ways
+# in on the box: the autologin root console, or append a key to
+# /root/.ssh/authorized_keys at runtime to enable SSH without a rebuild.
 #
 # Example (add below, uncommitted):
 #   ssh-ed25519 AAAAC3Nza... you@host

--- a/nix/debug-ssh-authorized-keys
+++ b/nix/debug-ssh-authorized-keys
@@ -1,8 +1,14 @@
 # SSH public keys allowed to log in as root on the DEBUG boot entry of the
 # reference-machine ISO (see nix/iso.nix → specialisation.debug).
 #
-# Add one public key per line, then rebuild the ISO (`nix build .#iso`) and
-# re-flash the stick. Key-only root SSH (PermitRootLogin=prohibit-password);
-# with no key here it's effectively disabled — use the autologin root console.
-
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDLI1nqsUQRLrACY32nEiHhpYF1bF94qwabbNoqF4XSzd0BG3f+be6wRNOIyEfT3IDGELLekUC1lscH4fIQYq2JUgCjXnS0wTg1U9dOKaGONlXH4dsS5x0zFjEzM+DCk9pqynbDW0FUhJ2ilLkhmeIfPzN0eYMLEBHCMK2GMxwgiMEYtncUcLSDhYD7xPVm2N+zmjvUrU36C9ogGGC6T6fQm2EUlNGuTQWIIIsif2LaFWqwc971a+9cwtmkDh9va7IjpsXr6z87z3vDmnrSVESyr6RGDr/ytbXzl1rzDJ3ni0xmRBPAgs3x0rpvqiMhnq1s2KkW9A0qhasCYDC9UBIAeshDQoLMuB+iJG3MhsEycg+6NLj5fTJtOw+coDfYLMq5PVD+tVlHjh/w4vr/WYQlJOY2D619mKvmRvrF95fZXcOck0+U5I5up0qlWx8FY1U1xQIeFlZivfYHTTadaDTEN5FPopMCbrP2f3kqdZB4bdl6zHBkOJwHsBt5K6FK/MRj/TZx/HMh5paiPqn9vbb8Krh3XzexIwXRSh7M2FCdi+FF4fcFP3AoaW2abIDdM7vMaxAsHEMGcH1FpMY54o0OKiP8LEhYBUSB0DnsSz3eZDLqZZqTs0XPQymIpoEowiC3QRwMNvNJdiD+Lc1uwUsneJRewkoS7vEzxnLyzE/F+Q== simon@macbook
+# Kept a PLACEHOLDER in the repo on purpose — a public project shouldn't ship a
+# specific person's authorisation. Add your own key(s) here in your WORKING COPY
+# (do NOT commit them) and build: `nix build .#iso` reads the working tree, so a
+# dirty-tree build bakes your key without it ever entering git history.
+#
+# Key-only root SSH (PermitRootLogin=prohibit-password); with no key here, key
+# auth is effectively off — use the autologin root console (grab the DHCP IP
+# with `ip a`, or `passwd`).
+#
+# Example (add below, uncommitted):
+#   ssh-ed25519 AAAAC3Nza... you@host

--- a/nix/debug-ssh-authorized-keys
+++ b/nix/debug-ssh-authorized-keys
@@ -1,0 +1,10 @@
+# SSH public keys allowed to log in as root on the DEBUG boot entry of the
+# reference-machine ISO (see nix/iso.nix → specialisation.debug).
+#
+# Add one public key per line, then rebuild the ISO (`nix build .#iso`) and
+# re-flash the stick. Until a key is present here, key-based root SSH is
+# effectively disabled (secure default) — use the autologin root console on the
+# box (grab the DHCP IP with `ip a`, or `passwd` to set a temporary password).
+#
+# Example:
+#   ssh-ed25519 AAAAC3Nza... simon@macbook

--- a/nix/gate.sh
+++ b/nix/gate.sh
@@ -94,7 +94,13 @@ npk_rev="${npk_rev:-unknown}"
 # real box).
 # Machine-wide state (always meaningful):
 ms_cmdline="$(cat /proc/cmdline 2>/dev/null || echo unknown)"
-ms_isolated="$(cat /sys/devices/system/cpu/isolated 2>/dev/null)"; ms_isolated="${ms_isolated:-<none>}"
+if [ -r /sys/devices/system/cpu/isolated ]; then
+  # File present: empty contents mean genuinely no isolated CPUs.
+  ms_isolated="$(cat /sys/devices/system/cpu/isolated)"; ms_isolated="${ms_isolated:-<none>}"
+else
+  # File absent (kernel doesn't expose it) — can't tell; don't misreport as <none>.
+  ms_isolated="<unknown (no /sys/.../cpu/isolated on this kernel)>"
+fi
 ms_online="$(cat /sys/devices/system/cpu/online 2>/dev/null || echo unknown)"
 ms_smt="$(cat /sys/devices/system/cpu/smt/control 2>/dev/null || echo n/a)"
 ms_boost="$(cat /sys/devices/system/cpu/cpufreq/boost 2>/dev/null || echo n/a)"           # AMD/acpi-cpufreq: 1=on 0=off
@@ -107,7 +113,8 @@ if [ -n "$GATE_CORE" ]; then
   ms_gov="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
   ms_min="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
   ms_max="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
-  # IRQs currently landing on the isolated core — should be ~0 if irqaffinity steered them away.
+  # Cumulative IRQ count on the isolated core SINCE BOOT (a total from
+  # /proc/interrupts, not a live rate) — should be ~0 if irqaffinity steered them away.
   ms_irq="$(awk -v core="$mc" 'NR==1{for(i=1;i<=NF;i++) if($i=="CPU"core) col=i+1} NR>1 && col && $col ~ /^[0-9]+$/ {s+=$col} END{print (col? s+0 : "n/a")}' /proc/interrupts 2>/dev/null || echo n/a)"
 else
   mc="<none>"; ms_gov="n/a"; ms_min="n/a"; ms_max="n/a"; ms_irq="n/a"
@@ -135,7 +142,7 @@ fi
   echo "core $mc gov  : $ms_gov   (want 'performance')"
   echo "core $mc freq : min=$ms_min max=$ms_max cur=$cur_khz kHz   (want min==max==cur, no throttle)"
   echo "boost/turbo : amd boost=$ms_boost (want 0)   intel no_turbo=$ms_noturbo (want 1)"
-  echo "core $mc IRQs : $ms_irq   (want ~0 — irqaffinity steered interrupts off the isolated core)"
+  echo "core $mc IRQs : $ms_irq   (cumulative since boot; want ~0 — irqaffinity steered interrupts off the isolated core)"
   echo "=========================================================================="
   echo
 } > "$REPORT"

--- a/nix/gate.sh
+++ b/nix/gate.sh
@@ -79,7 +79,7 @@ step() { timeout "$GATE_TIMEOUT" "$@"; }
 cpu_model="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ //' || echo unknown)"
 microcode="$(grep -m1 microcode /proc/cpuinfo 2>/dev/null | cut -d: -f2- | tr -d ' ' || echo unknown)"
 kernel="$(uname -r 2>/dev/null || echo unknown)"
-cur_khz="$([ -n "$GATE_CORE" ] && cat /sys/devices/system/cpu/cpu$GATE_CORE/cpufreq/scaling_cur_freq 2>/dev/null || echo n/a)"
+cur_khz="$([ -n "$GATE_CORE" ] && cat /sys/devices/system/cpu/cpu"$GATE_CORE"/cpufreq/scaling_cur_freq 2>/dev/null || echo n/a)"
 src_rev="${GATE_SOURCE_REV:-$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)}"
 # Parse the nixpkgs node's rev specifically (ruby+JSON — always available here),
 # not the first "rev" in flake.lock, which stops being nixpkgs the moment another
@@ -110,9 +110,9 @@ ms_noturbo="$(cat /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null || e
 # core" while the header says isolated=<none> (that would be inconsistent).
 if [ -n "$GATE_CORE" ]; then
   mc="$GATE_CORE"
-  ms_gov="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
-  ms_min="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
-  ms_max="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
+  ms_gov="$(cat /sys/devices/system/cpu/cpu"$mc"/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
+  ms_min="$(cat /sys/devices/system/cpu/cpu"$mc"/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
+  ms_max="$(cat /sys/devices/system/cpu/cpu"$mc"/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
   # Cumulative IRQ count on the isolated core SINCE BOOT (a total from
   # /proc/interrupts, not a live rate) — should be ~0 if irqaffinity steered them away.
   ms_irq="$(awk -v core="$mc" 'NR==1{for(i=1;i<=NF;i++) if($i=="CPU"core) col=i+1} NR>1 && col && $col ~ /^[0-9]+$/ {s+=$col} END{print (col? s+0 : "n/a")}' /proc/interrupts 2>/dev/null || echo n/a)"

--- a/nix/gate.sh
+++ b/nix/gate.sh
@@ -87,6 +87,24 @@ src_rev="${GATE_SOURCE_REV:-$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null 
 npk_rev="${GATE_NIXPKGS_REV:-$(ruby -rjson -e 'begin; print(JSON.parse(File.read(ARGV[0])).dig("nodes","nixpkgs","locked","rev").to_s[0,12]); rescue; end' "$ROOT/flake.lock" 2>/dev/null)}"
 npk_rev="${npk_rev:-unknown}"
 
+# --- machine-state diagnostics -----------------------------------------------
+# Stamp what the quiet-machine config ACTUALLY did, so a single bare-metal run
+# reveals a knob that didn't take (e.g. isolcpus wrong for this CPU, boost still
+# on) — instead of a silent physical round-trip. All best-effort ("n/a" off the
+# real box). $mc = the isolated (measurement) core.
+mc="${GATE_CORE:-0}"
+ms_cmdline="$(cat /proc/cmdline 2>/dev/null || echo unknown)"
+ms_isolated="$(cat /sys/devices/system/cpu/isolated 2>/dev/null)"; ms_isolated="${ms_isolated:-<none>}"
+ms_online="$(cat /sys/devices/system/cpu/online 2>/dev/null || echo unknown)"
+ms_smt="$(cat /sys/devices/system/cpu/smt/control 2>/dev/null || echo n/a)"
+ms_gov="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
+ms_min="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
+ms_max="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
+ms_boost="$(cat /sys/devices/system/cpu/cpufreq/boost 2>/dev/null || echo n/a)"           # AMD/acpi-cpufreq: 1=on 0=off
+ms_noturbo="$(cat /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null || echo n/a)" # Intel pstate: 1=turbo off
+# IRQs currently landing on the isolated core — should be ~0 if irqaffinity steered them away.
+ms_irq="$(awk -v core="$mc" 'NR==1{for(i=1;i<=NF;i++) if($i=="CPU"core) col=i+1} NR>1 && col && $col ~ /^[0-9]+$/ {s+=$col} END{print (col? s+0 : "n/a")}' /proc/interrupts 2>/dev/null || echo n/a)"
+
 {
   echo "=========================================================================="
   echo "secp256k1-native — timing-verification reference machine report"
@@ -101,6 +119,15 @@ npk_rev="${npk_rev:-unknown}"
   echo "nixpkgs rev : $npk_rev"
   echo "dudect runs : $GATE_DUDECT_RUNS   threshold |t|<$THRESHOLD (strict) / mean|t|<$GATE_LENIENT_MEAN (operand-artefact ops)"
   echo "compilers   : $GATE_COMPILERS"
+  echo "-------------------------------- machine state (did the quiet config take?) --"
+  echo "cmdline     : $ms_cmdline"
+  echo "isolated    : $ms_isolated   (kernel-reported isolated CPUs; want the measurement core listed)"
+  echo "online cpus : $ms_online"
+  echo "SMT         : $ms_smt   (want 'off'/'forceoff')"
+  echo "core $mc gov  : $ms_gov   (want 'performance')"
+  echo "core $mc freq : min=$ms_min max=$ms_max cur=$cur_khz kHz   (want min==max==cur, no throttle)"
+  echo "boost/turbo : amd boost=$ms_boost (want 0)   intel no_turbo=$ms_noturbo (want 1)"
+  echo "core $mc IRQs : $ms_irq   (want ~0 — irqaffinity steered interrupts off the isolated core)"
   echo "=========================================================================="
   echo
 } > "$REPORT"

--- a/nix/gate.sh
+++ b/nix/gate.sh
@@ -79,7 +79,7 @@ step() { timeout "$GATE_TIMEOUT" "$@"; }
 cpu_model="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ //' || echo unknown)"
 microcode="$(grep -m1 microcode /proc/cpuinfo 2>/dev/null | cut -d: -f2- | tr -d ' ' || echo unknown)"
 kernel="$(uname -r 2>/dev/null || echo unknown)"
-cur_khz="$(cat /sys/devices/system/cpu/cpu${GATE_CORE:-0}/cpufreq/scaling_cur_freq 2>/dev/null || echo unknown)"
+cur_khz="$([ -n "$GATE_CORE" ] && cat /sys/devices/system/cpu/cpu$GATE_CORE/cpufreq/scaling_cur_freq 2>/dev/null || echo n/a)"
 src_rev="${GATE_SOURCE_REV:-$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)}"
 # Parse the nixpkgs node's rev specifically (ruby+JSON — always available here),
 # not the first "rev" in flake.lock, which stops being nixpkgs the moment another
@@ -91,19 +91,27 @@ npk_rev="${npk_rev:-unknown}"
 # Stamp what the quiet-machine config ACTUALLY did, so a single bare-metal run
 # reveals a knob that didn't take (e.g. isolcpus wrong for this CPU, boost still
 # on) — instead of a silent physical round-trip. All best-effort ("n/a" off the
-# real box). $mc = the isolated (measurement) core.
-mc="${GATE_CORE:-0}"
+# real box).
+# Machine-wide state (always meaningful):
 ms_cmdline="$(cat /proc/cmdline 2>/dev/null || echo unknown)"
 ms_isolated="$(cat /sys/devices/system/cpu/isolated 2>/dev/null)"; ms_isolated="${ms_isolated:-<none>}"
 ms_online="$(cat /sys/devices/system/cpu/online 2>/dev/null || echo unknown)"
 ms_smt="$(cat /sys/devices/system/cpu/smt/control 2>/dev/null || echo n/a)"
-ms_gov="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
-ms_min="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
-ms_max="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
 ms_boost="$(cat /sys/devices/system/cpu/cpufreq/boost 2>/dev/null || echo n/a)"           # AMD/acpi-cpufreq: 1=on 0=off
 ms_noturbo="$(cat /sys/devices/system/cpu/intel_pstate/no_turbo 2>/dev/null || echo n/a)" # Intel pstate: 1=turbo off
-# IRQs currently landing on the isolated core — should be ~0 if irqaffinity steered them away.
-ms_irq="$(awk -v core="$mc" 'NR==1{for(i=1;i<=NF;i++) if($i=="CPU"core) col=i+1} NR>1 && col && $col ~ /^[0-9]+$/ {s+=$col} END{print (col? s+0 : "n/a")}' /proc/interrupts 2>/dev/null || echo n/a)"
+# Per-core state is only meaningful when a core is actually pinned. In dev/CI
+# (GATE_CORE unset) report n/a — don't stamp core 0's stats as "the measured
+# core" while the header says isolated=<none> (that would be inconsistent).
+if [ -n "$GATE_CORE" ]; then
+  mc="$GATE_CORE"
+  ms_gov="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
+  ms_min="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_min_freq 2>/dev/null || echo n/a)"
+  ms_max="$(cat /sys/devices/system/cpu/cpu$mc/cpufreq/scaling_max_freq 2>/dev/null || echo n/a)"
+  # IRQs currently landing on the isolated core — should be ~0 if irqaffinity steered them away.
+  ms_irq="$(awk -v core="$mc" 'NR==1{for(i=1;i<=NF;i++) if($i=="CPU"core) col=i+1} NR>1 && col && $col ~ /^[0-9]+$/ {s+=$col} END{print (col? s+0 : "n/a")}' /proc/interrupts 2>/dev/null || echo n/a)"
+else
+  mc="<none>"; ms_gov="n/a"; ms_min="n/a"; ms_max="n/a"; ms_irq="n/a"
+fi
 
 {
   echo "=========================================================================="

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -161,7 +161,7 @@ in
     users.motd = ''
       secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run.
       Run the gate by hand from a writable copy of the read-only baked source:
-        rm -rf /root/src && cp -a /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
+        rm -rf /root/src && cp -aL /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
         GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
     '';
   };

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -76,7 +76,7 @@ in
       #    (The `debug` boot-menu entry skips the sweep and leaves them up for
       #    interactive SSH access instead.)
       systemctl stop sshd.service systemd-networkd.service systemd-timesyncd.service \
-                     NetworkManager.service 'wpa_supplicant*' 2>/dev/null || true
+                     NetworkManager.service dhcpcd.service 'wpa_supplicant*' 2>/dev/null || true
 
       # 1. Writable copy of the baked source (store is read-only).
       work=/run/timing-gate/src
@@ -161,7 +161,7 @@ in
     users.motd = ''
       secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run.
       Run the gate by hand from a writable copy of the read-only baked source:
-        cp -a /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
+        rm -rf /root/src && cp -a /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
         GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
     '';
   };

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -139,9 +139,12 @@ in
   # stay up, and the box does NOT power off — SSH in and drive `bash nix/gate.sh`
   # by hand, or tune sysfs and re-run.
   #
-  # SSH access is KEY-ONLY: add your public key(s) to nix/debug-ssh-authorized-keys
-  # and rebuild. Until you do, the autologin root console is the way in (grab the
-  # DHCP IP with `ip a`, or set a password with `passwd`).
+  # SSH access is KEY-ONLY (PermitRootLogin=prohibit-password): add your public
+  # key(s) to nix/debug-ssh-authorized-keys and rebuild. Without a baked key,
+  # log in on the autologin root console (grab the DHCP IP with `ip a`); to
+  # enable SSH ad-hoc without a rebuild, append a key to
+  # /root/.ssh/authorized_keys there. (Password SSH is off, so `passwd` only
+  # helps the local console, not SSH.)
   specialisation.debug.configuration = {
     system.nixos.tags = [ "debug" ];
     # No unattended sweep on this entry.
@@ -153,7 +156,13 @@ in
     };
     users.users.root.openssh.authorizedKeys.keyFiles = [ ./debug-ssh-authorized-keys ];
     networking.hostName = lib.mkForce "secp256k1-debug";
-    # A visible hint on the console about the mode.
-    users.motd = "secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run. `bash /etc/secp256k1-native/source/nix/gate.sh` to run the gate by hand.";
+    # Console hint. NB: the baked source is a READ-ONLY nix store copy, so the
+    # gate (which clobbers + builds in-tree) must run from a WRITABLE copy.
+    users.motd = ''
+      secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run.
+      Run the gate by hand from a writable copy of the read-only baked source:
+        cp -a /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
+        GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
+    '';
   };
 }

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -9,7 +9,7 @@
 # Prototype: gcc15 only (gccSet in flake.nix). Widen the set once it boots on
 # bare metal (Phase 7). The measurement is meaningful ONLY on quiet bare metal —
 # a VM/Docker run validates the boot→sweep→report→halt AUTOMATION, not timing.
-{ config, lib, pkgs, modulesPath, refSource, gateGems, gccSet, gateTools, ... }:
+{ config, lib, pkgs, modulesPath, refSource, gateGems, gccSet, gateTools, valgrindCFlags, ... }:
 
 let
   isolatedCore = config.referenceMachine.isolatedCore;
@@ -57,6 +57,10 @@ in
       StandardError = "tty";
       TTYPath = "/dev/tty1";
     };
+    # The ctgrind build needs <valgrind/memcheck.h> from valgrind's `dev` output,
+    # which isn't on the default include path (see valgrindCFlags in flake.nix).
+    # A systemd service gets a clean env, so set it here explicitly.
+    environment.NIX_CFLAGS_COMPILE = valgrindCFlags;
     # gateTools already provides util-linux (mount/umount/blkid) and coreutils
     # (sync); no need to re-add them. Keep the PATH minimal (principle 3).
     path = gateTools;
@@ -162,7 +166,7 @@ in
       secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run.
       Run the gate by hand from a writable copy of the read-only baked source:
         rm -rf /root/src && cp -aL /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
-        GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
+        NIX_CFLAGS_COMPILE="${valgrindCFlags}" GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
     '';
   };
 }

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -25,7 +25,9 @@ in
   # A minimal live ISO (installation-cd-minimal) as the base image.
   imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix" ];
 
-  # Turn on the quiet-machine boot state (isolcpus, freq pin, no network, …).
+  # Turn on the quiet-machine boot state (isolcpus, freq pin, SMT off, …).
+  # (It doesn't disable networking — the sweep service stops the network daemons
+  # before measuring; see below.)
   referenceMachine.enable = true;
   # referenceMachine.isolatedCore / .cpuVendor default to 15 / amd — override per
   # box here when the real hardware is known.
@@ -70,7 +72,7 @@ in
       warn() { echo "timing-gate: $*" | tee /dev/tty1 /dev/console 2>/dev/null || true; }
 
       # 0. Quiet: this is the UNATTENDED sweep, so stop the network + ssh daemons
-      #    the base image starts — DHCP/NTP/ssh activity is measurement noise.
+      #    that the base image starts — DHCP/NTP/ssh activity is measurement noise.
       #    (The `debug` boot-menu entry skips the sweep and leaves them up for
       #    interactive SSH access instead.)
       systemctl stop sshd.service systemd-networkd.service systemd-timesyncd.service \

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -69,6 +69,13 @@ in
       trap 'sync; umount /mnt 2>/dev/null || true; [ -n "$no_poweroff" ] || systemctl poweroff' EXIT
       warn() { echo "timing-gate: $*" | tee /dev/tty1 /dev/console 2>/dev/null || true; }
 
+      # 0. Quiet: this is the UNATTENDED sweep, so stop the network + ssh daemons
+      #    the base image starts — DHCP/NTP/ssh activity is measurement noise.
+      #    (The `debug` boot-menu entry skips the sweep and leaves them up for
+      #    interactive SSH access instead.)
+      systemctl stop sshd.service systemd-networkd.service systemd-timesyncd.service \
+                     NetworkManager.service 'wpa_supplicant*' 2>/dev/null || true
+
       # 1. Writable copy of the baked source (store is read-only).
       work=/run/timing-gate/src
       rm -rf "$work"; mkdir -p "$work"
@@ -119,5 +126,32 @@ in
       # read as a clean service success.
       exit "$gate_rc"
     '';
+  };
+
+  # --- Interactive debug boot entry (a specialisation ⇒ a second boot-menu
+  # entry the nixpkgs ISO module generates for GRUB + isolinux). The ISO menu's
+  # existing timeout auto-boots the default (unattended sweep); arrow to
+  # "debug" + enter to get a networked shell instead. Build-time, so no runtime
+  # tty-prompt fragility. Same quiet-machine kernel params (isolation stays on
+  # so you can test its effect), but: the sweep does NOT run, networking + sshd
+  # stay up, and the box does NOT power off — SSH in and drive `bash nix/gate.sh`
+  # by hand, or tune sysfs and re-run.
+  #
+  # SSH access is KEY-ONLY: add your public key(s) to nix/debug-ssh-authorized-keys
+  # and rebuild. Until you do, the autologin root console is the way in (grab the
+  # DHCP IP with `ip a`, or set a password with `passwd`).
+  specialisation.debug.configuration = {
+    system.nixos.tags = [ "debug" ];
+    # No unattended sweep on this entry.
+    systemd.services.timing-gate.wantedBy = lib.mkForce [ ];
+    # SSH in for interactive tuning.
+    services.openssh = {
+      enable = true;
+      settings.PermitRootLogin = "prohibit-password"; # key-only root
+    };
+    users.users.root.openssh.authorizedKeys.keyFiles = [ ./debug-ssh-authorized-keys ];
+    networking.hostName = lib.mkForce "secp256k1-debug";
+    # A visible hint on the console about the mode.
+    users.motd = "secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run. `bash /etc/secp256k1-native/source/nix/gate.sh` to run the gate by hand.";
   };
 }

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -166,7 +166,7 @@ in
       secp256k1 reference machine — DEBUG boot: network + sshd up, sweep NOT run.
       Run the gate by hand from a writable copy of the read-only baked source:
         rm -rf /root/src && cp -aL /etc/secp256k1-native/source /root/src && chmod -R u+w /root/src && cd /root/src
-        NIX_CFLAGS_COMPILE="${valgrindCFlags}" GATE_RUBY_EXEC="" GATE_CORE=15 GATE_OUT=/root/out bash nix/gate.sh
+        NIX_CFLAGS_COMPILE="${valgrindCFlags}" GATE_RUBY_EXEC="" GATE_CORE=${toString isolatedCore} GATE_OUT=/root/out bash nix/gate.sh
     '';
   };
 }

--- a/nix/iso.nix
+++ b/nix/iso.nix
@@ -156,7 +156,18 @@ in
     # SSH in for interactive tuning.
     services.openssh = {
       enable = true;
-      settings.PermitRootLogin = "prohibit-password"; # key-only root
+      settings = {
+        PermitRootLogin = "prohibit-password"; # key-only root
+        # Defence-in-depth: this is a key-only appliance, so pin the whole
+        # password/interactive surface off rather than leaning on upstream
+        # defaults. The empty-password installer `nixos` account is remotely
+        # inert today ONLY because sshd's PermitEmptyPasswords defaults to no and
+        # the PAM auth line carries no nullok; a future base-profile change could
+        # silently reopen that. No mkForce needed — the installer profile leaves
+        # these at the module default (true), so a plain assignment overrides.
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+      };
     };
     users.users.root.openssh.authorizedKeys.keyFiles = [ ./debug-ssh-authorized-keys ];
     networking.hostName = lib.mkForce "secp256k1-debug";

--- a/nix/reference-machine.nix
+++ b/nix/reference-machine.nix
@@ -107,10 +107,13 @@ in
         # noise source on the first bare-metal run (fadd |t| 213 -> ~1 once
         # disabled; the pinned min=max frequency does NOT prevent this). Disable
         # every non-POLL cpuidle state on the measurement core so its idle loop
-        # busy-polls at the pinned frequency. Only the isolated core — the
-        # housekeeping cores idle normally to save power.
-        for s in /sys/devices/system/cpu/cpu${toString cfg.isolatedCore}/cpuidle/state[1-9]*/disable; do
-          [ -w "$s" ] && echo 1 > "$s" 2>/dev/null || true
+        # busy-polls at the pinned frequency. Match POLL by NAME rather than
+        # assuming it is state0 — it is on x86, but don't rely on the index; a
+        # non-POLL state left enabled would reintroduce the wake/ramp jitter.
+        # Only the isolated core — the housekeeping cores idle normally to save power.
+        for s in /sys/devices/system/cpu/cpu${toString cfg.isolatedCore}/cpuidle/state*; do
+          [ "$(cat "$s/name" 2>/dev/null)" = POLL ] && continue
+          [ -w "$s/disable" ] && echo 1 > "$s/disable" 2>/dev/null || true
         done
       '' + lib.optionalString (cfg.cpuVendor == "amd") ''
         # AMD: global boost knob (acpi-cpufreq / amd-pstate).

--- a/nix/reference-machine.nix
+++ b/nix/reference-machine.nix
@@ -3,7 +3,8 @@
 # Quiet-machine NixOS module for the timing-verification reference machine
 # (Phase 2 of plans/61-reference-machine-nix.md). Boot-level state that makes
 # the dudect pre-tag gate reproducible: one isolated CPU core with no scheduler
-# / IRQ / RCU noise, pinned frequency (no DVFS/turbo jitter), and SMT off.
+# / IRQ / RCU noise, pinned frequency (no DVFS/turbo jitter), no deep-idle wake
+# jitter (C-states forced to POLL on that core), and SMT off.
 # Imported by nix/iso.nix; also usable for a persistent box later.
 #
 # NB: this module does NOT disable networking — network *quiet during the
@@ -81,7 +82,7 @@ in
     # perturb the measurement. Ordered before the gate so the sweep runs pinned;
     # the report stamps the achieved frequency so residual throttling is visible.
     systemd.services.reference-machine-freq-pin = {
-      description = "Pin CPU frequency and disable turbo/boost for timing stability";
+      description = "Pin CPU frequency, disable turbo/boost, and force the isolated core out of deep idle for timing stability";
       wantedBy = [ "multi-user.target" ];
       before = [ "timing-gate.service" ];
       after = [ "sysinit.target" ];
@@ -98,6 +99,18 @@ in
           max=$(cat "$p/cpuinfo_max_freq")
           echo "$max" > "$p/scaling_min_freq" 2>/dev/null || true
           echo "$max" > "$p/scaling_max_freq" 2>/dev/null || true
+        done
+        # Force the isolated core out of deep idle. A core that enters a deep
+        # C-state between measurements pays a frequency-ramp penalty on wake
+        # (empirically ~4.3 -> ~4.0 GHz for the first microseconds after C3),
+        # surfacing as ns-scale jitter in the fastest field ops — the dominant
+        # noise source on the first bare-metal run (fadd |t| 213 -> ~1 once
+        # disabled; the pinned min=max frequency does NOT prevent this). Disable
+        # every non-POLL cpuidle state on the measurement core so its idle loop
+        # busy-polls at the pinned frequency. Only the isolated core — the
+        # housekeeping cores idle normally to save power.
+        for s in /sys/devices/system/cpu/cpu${toString cfg.isolatedCore}/cpuidle/state[1-9]*/disable; do
+          [ -w "$s" ] && echo 1 > "$s" 2>/dev/null || true
         done
       '' + lib.optionalString (cfg.cpuVendor == "amd") ''
         # AMD: global boost knob (acpi-cpufreq / amd-pstate).

--- a/nix/reference-machine.nix
+++ b/nix/reference-machine.nix
@@ -3,8 +3,13 @@
 # Quiet-machine NixOS module for the timing-verification reference machine
 # (Phase 2 of plans/61-reference-machine-nix.md). Boot-level state that makes
 # the dudect pre-tag gate reproducible: one isolated CPU core with no scheduler
-# / IRQ / RCU noise, pinned frequency (no DVFS/turbo jitter), SMT off, and no
-# network. Imported by nix/iso.nix; also usable for a persistent box later.
+# / IRQ / RCU noise, pinned frequency (no DVFS/turbo jitter), and SMT off.
+# Imported by nix/iso.nix; also usable for a persistent box later.
+#
+# NB: this module does NOT disable networking — network *quiet during the
+# measurement* is the sweep service's job (it stops the network daemons right
+# before measuring; see nix/iso.nix), which lets the debug boot entry keep the
+# network up for SSH without fighting an mkForce here.
 #
 # Why boot-level: the quiet state is a property of the kernel command line and
 # early sysfs, NOT of userspace. That is exactly why one boot can sweep every

--- a/nix/reference-machine.nix
+++ b/nix/reference-machine.nix
@@ -103,14 +103,11 @@ in
       '';
     };
 
-    # --- No network ----------------------------------------------------------
-    # Source is baked and results go to USB; DHCP/NTP/etc. are pure measurement
-    # noise and attack surface. (networkd itself is left to the base image;
-    # disabling the active clients is what removes the noise.)
-    networking.useDHCP = lib.mkForce false;
-    networking.dhcpcd.enable = lib.mkForce false;
-    networking.networkmanager.enable = lib.mkForce false;
-    networking.wireless.enable = lib.mkForce false;
+    # --- Network quiet is the SWEEP's job, not a hard module policy -----------
+    # DHCP/NTP/etc. are measurement noise, so the sweep stops the network daemons
+    # (incl. wpa_supplicant) right before it measures (see nix/iso.nix). This
+    # module deliberately does NOT touch networking, so a `debug` boot
+    # specialisation can leave it up for SSH without fighting an mkForce here.
 
     # --- Console-only + autologin fallback -----------------------------------
     # No display manager / X. Autologin root so an operator can intervene on the


### PR DESCRIPTION
## Summary

Makes the bare-metal Phase 7 iteration loop (#61) workable. Two additions:

1. **Machine-state diagnostics** in the gate's provenance report — so a quiet-machine knob that silently didn't take is a visible report line, not a wasted physical round-trip.
2. **`debug` boot-menu entry** — a NixOS `specialisation` (surfaced by the ISO module in GRUB + isolinux) that boots to network + `sshd` with **no** sweep and **no** poweroff, so you can SSH in and tune/measure interactively. The ISO menu's existing timeout auto-boots the unattended sweep default; arrow to `debug` for the shell.

Additive; the sweep default is unchanged. Quiet-during-measurement is now the sweep service's job (stops network/ssh daemons right before measuring), which let the debug entry re-use networking cleanly.

## What's in the report now

```
-------- machine state (did the quiet config take?) --
cmdline     : … isolcpus=… nosmt nohz_full=… irqaffinity=0-14 …
isolated    : 15
SMT         : off        (want off/forceoff)
core 15 gov : performance
core 15 freq: min==max==cur   (no throttle)
boost/turbo : amd boost=0     intel no_turbo=…
core 15 IRQs: 0          (irqaffinity steered them off)
```

## Test plan

- `nix eval` — base ISO derivation **and** the `debug` specialisation toplevel both evaluate.
- `nix build .#iso` succeeds; the built image's boot config (BIOS isolinux + UEFI GRUB) contains **both** entries: the default and `NixOS debug-… Installer` (grepped from the ISO).
- Machine-state gathering parses `/proc` + sysfs without error (graceful `n/a` off the box).

## Known limitation (not silent)

**Not boot-tested.** The menu entry is confirmed present in the artifact, but DHCP coming up, `sshd` starting, and the sweep-mode network-stop only prove out on real hardware — that's Phase 7, on the box.

## Notes

- SSH is key-only (`PermitRootLogin=prohibit-password`); add a public key to `nix/debug-ssh-authorized-keys` and rebuild. Autologin-root console is the first-boot way in.
- Building ISOs stays in Docker; the debug box is a measurement rig driven over SSH.

Closes #70. Part of #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)